### PR TITLE
Add logout buttons to samples

### DIFF
--- a/samples/IdentityServerSample/Controllers/AccountController.cs
+++ b/samples/IdentityServerSample/Controllers/AccountController.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
+using IdentityServer4.Models;
 using IdentityServer4.Services;
 using IdentityServerSample.Models;
 using Microsoft.AspNetCore.Authentication;
@@ -72,10 +73,26 @@ namespace IdentityServerSample.Controllers
             return Redirect("~/");
         }
 
-        public async Task<IActionResult> Logout()
+        [HttpGet]
+        public async Task<IActionResult> Logout(string logoutId)
+        {
+            LogoutRequest logoutRequest = await _interaction.GetLogoutContextAsync(logoutId);
+            var returnUrl = logoutRequest?.PostLogoutRedirectUri;
+
+            return await Logout(new LogoutModel { ReturnUrl = returnUrl });
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> Logout(LogoutModel model)
         {
             await HttpContext.SignOutAsync();
-            return Redirect("~/");
+
+            return Redirect(model?.ReturnUrl ?? "~/");
+        }
+
+        public class LogoutModel
+        {
+            public string ReturnUrl { get; set; }
         }
     }
 }

--- a/samples/IdentityServerSample/Controllers/AccountController.cs
+++ b/samples/IdentityServerSample/Controllers/AccountController.cs
@@ -71,5 +71,11 @@ namespace IdentityServerSample.Controllers
 
             return Redirect("~/");
         }
+
+        public async Task<IActionResult> Logout()
+        {
+            await HttpContext.SignOutAsync();
+            return Redirect("~/");
+        }
     }
 }

--- a/samples/IdentityServerSample/Views/Shared/_Layout.cshtml
+++ b/samples/IdentityServerSample/Views/Shared/_Layout.cshtml
@@ -25,7 +25,9 @@
             <a asp-area="" asp-controller="Home" asp-action="Index" class="navbar-brand">ActiveLogin - IdentityServerSample</a>
             @if (User.Identity?.IsAuthenticated == true)
             {
-                <a asp-area="" asp-controller="Account" asp-action="Logout" class="btn btn-primary">Logout</a>
+                <form method = "post" asp-area="" asp-controller="Account" asp-action="Logout"> 
+                    <input type="submit" value="Logout" class="btn btn-primary"/> 
+                </form> 
             }
         </div>
     </nav>

--- a/samples/IdentityServerSample/Views/Shared/_Layout.cshtml
+++ b/samples/IdentityServerSample/Views/Shared/_Layout.cshtml
@@ -23,6 +23,10 @@
     <nav class="navbar navbar-dark bg-dark fixed-top">
         <div class="container">
             <a asp-area="" asp-controller="Home" asp-action="Index" class="navbar-brand">ActiveLogin - IdentityServerSample</a>
+            @if (User.Identity?.IsAuthenticated == true)
+            {
+                <a asp-area="" asp-controller="Account" asp-action="Logout" class="btn btn-primary">Logout</a>
+            }
         </div>
     </nav>
 

--- a/samples/MvcClientSample/Controllers/HomeController.cs
+++ b/samples/MvcClientSample/Controllers/HomeController.cs
@@ -13,6 +13,7 @@ namespace MvcClientSample.Controllers
             });
         }
 
+        [HttpPost]
         public IActionResult Logout()
         {
             return new SignOutResult(new[] { "Cookies", "oidc" });

--- a/samples/MvcClientSample/Controllers/HomeController.cs
+++ b/samples/MvcClientSample/Controllers/HomeController.cs
@@ -12,5 +12,10 @@ namespace MvcClientSample.Controllers
                 Claims = User.Claims
             });
         }
+
+        public IActionResult Logout()
+        {
+            return new SignOutResult(new[] { "Cookies", "oidc" });
+        }
     }
 }

--- a/samples/MvcClientSample/Views/Shared/_Layout.cshtml
+++ b/samples/MvcClientSample/Views/Shared/_Layout.cshtml
@@ -16,6 +16,10 @@
     <nav class="navbar  navbar-dark bg-primary fixed-top">
         <div class="container">
             <a asp-area="" asp-controller="Home" asp-action="Index" class="navbar-brand">ActiveLogin - MvcClientSample</a>
+            @if (User.Identity?.IsAuthenticated == true)
+            {
+                <a asp-area="" asp-controller="Home" asp-action="Logout" class="btn btn-primary">Logout</a>
+            }
         </div>
     </nav>
 

--- a/samples/MvcClientSample/Views/Shared/_Layout.cshtml
+++ b/samples/MvcClientSample/Views/Shared/_Layout.cshtml
@@ -18,7 +18,9 @@
             <a asp-area="" asp-controller="Home" asp-action="Index" class="navbar-brand">ActiveLogin - MvcClientSample</a>
             @if (User.Identity?.IsAuthenticated == true)
             {
-                <a asp-area="" asp-controller="Home" asp-action="Logout" class="btn btn-primary">Logout</a>
+                <form method="post" asp-area="" asp-controller="Home" asp-action="Logout">
+                    <input type="submit" value="Logout" class="btn btn-primary" />
+                </form>
             }
         </div>
     </nav>

--- a/test/ActiveLogin.Authentication.BankId.Api.Test/BankIdDevelopmentApiClient_Tests.cs
+++ b/test/ActiveLogin.Authentication.BankId.Api.Test/BankIdDevelopmentApiClient_Tests.cs
@@ -17,14 +17,14 @@ namespace ActiveLogin.Authentication.BankId.Api.Test
         }
 
         [Fact]
-        public async void StartingTwoAuthenticationFlows__AtTheSameTime__ShouldThrow()
+        public async void AuthAsync__WithSamePersonalIdentityNumber_AtTheSameTime__ShouldThrow()
         {
             await _bankIdClient.AuthAsync(new AuthRequest("1.1.1.1", "199908072391"));
             await Assert.ThrowsAsync<BankIdApiException>(() => _bankIdClient.AuthAsync(new AuthRequest("1.1.1.2", "199908072391")));
         }
 
         [Fact]
-        public async void StartingTwoAuthenticationFlows__AfterOneAnother__ShouldBeAllowed()
+        public async void AuthAsync__WithSamePersonalIdentityNumber_OneAtTheTime__ShouldBeAllowed()
         {
             AuthResponse authResponse = await _bankIdClient.AuthAsync(new AuthRequest("1.1.1.1", "199908072391"));
             CollectResponse response;

--- a/test/ActiveLogin.Authentication.BankId.Api.Test/BankIdDevelopmentApiClient_Tests.cs
+++ b/test/ActiveLogin.Authentication.BankId.Api.Test/BankIdDevelopmentApiClient_Tests.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using ActiveLogin.Authentication.BankId.Api.Models;
+using Xunit;
+
+namespace ActiveLogin.Authentication.BankId.Api.Test
+{
+    public class BankIdDevelopmentApiClient_Tests
+    {
+        private readonly BankIdDevelopmentApiClient _bankIdClient;
+
+        public BankIdDevelopmentApiClient_Tests()
+        {
+            _bankIdClient = new BankIdDevelopmentApiClient
+            {
+                Delay = TimeSpan.Zero
+            };
+        }
+
+        [Fact]
+        public async void StartingTwoAuthenticationFlows__AtTheSameTime__ShouldThrow()
+        {
+            await _bankIdClient.AuthAsync(new AuthRequest("1.1.1.1", "199908072391"));
+            await Assert.ThrowsAsync<BankIdApiException>(() => _bankIdClient.AuthAsync(new AuthRequest("1.1.1.2", "199908072391")));
+        }
+
+        [Fact]
+        public async void StartingTwoAuthenticationFlows__AfterOneAnother__ShouldBeAllowed()
+        {
+            AuthResponse authResponse = await _bankIdClient.AuthAsync(new AuthRequest("1.1.1.1", "199908072391"));
+            CollectResponse response;
+            do
+            {
+                response = await _bankIdClient.CollectAsync(new CollectRequest(authResponse.OrderRef));
+            } while (response.Status != CollectStatus.Complete);
+
+            response = null;
+
+            authResponse = await _bankIdClient.AuthAsync(new AuthRequest("1.1.1.2", "199908072391"));
+            do
+            {
+                response = await _bankIdClient.CollectAsync(new CollectRequest(authResponse.OrderRef));
+            } while (response.Status != CollectStatus.Complete);
+
+            Assert.True(true, "Did not throw");
+        }
+    }
+}


### PR DESCRIPTION
This PR implements the logout buttons mentioned in #11

It includes changes that:
1. Adds logout button and functionality to the `MVC Client Sample`
2. Adds logout button and functionality to the `Identity Server Sample` 
3. Fixes a bug that prevented the user to perform more than one login attempt in a row in dev mode
4. Adds test to verify the bug fix mentioned above