### PR TITLE
Fix HTTP Client registration

### DIFF
--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdAuthenticationBuilder.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdAuthenticationBuilder.cs
@@ -5,7 +5,6 @@ using System.Security.Authentication;
 using ActiveLogin.Authentication.BankId.Api;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace ActiveLogin.Authentication.BankId.AspNetCore
 {
@@ -20,10 +19,6 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore
         {
             AuthenticationBuilder = authenticationBuilder;
 
-            var services = AuthenticationBuilder.Services;
-
-            AddBankIdHttpClient(services, _httpClientConfigurators, _httpClientHandlerConfigurators);
-
             ConfigureBankIdHttpClient(httpClient => httpClient.BaseAddress = BankIdUrls.ProdApiBaseUrl);
             ConfigureBankIdHttpClientHandler(httpClientHandler => httpClientHandler.SslProtocols = SslProtocols.Tls12);
         }
@@ -37,17 +32,17 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore
         {
             _httpClientHandlerConfigurators.Add(configureHttpClientHandler);
         }
-            
-        private static void AddBankIdHttpClient(IServiceCollection services, List<Action<HttpClient>> httpClientConfigurators, List<Action<HttpClientHandler>> httpClientHandlerConfigurators)
+
+        public void EnableBankIdHttpClient()
         {
-            services.AddHttpClient<IBankIdApiClient, BankIdApiClient>(httpClient =>
+            AuthenticationBuilder.Services.AddHttpClient<IBankIdApiClient, BankIdApiClient>(httpClient =>
                 {
-                    httpClientConfigurators.ForEach(configurator => configurator(httpClient));
+                    _httpClientConfigurators.ForEach(configurator => configurator(httpClient));
                 })
                 .ConfigurePrimaryHttpMessageHandler(() =>
                 {
                     var httpClientHandler = new HttpClientHandler();
-                    httpClientHandlerConfigurators.ForEach(configurator => configurator(httpClientHandler));
+                    _httpClientHandlerConfigurators.ForEach(configurator => configurator(httpClientHandler));
                     return httpClientHandler;
                 });
         }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdAuthenticationBuilder.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdAuthenticationBuilder.cs
@@ -19,21 +19,21 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore
         {
             AuthenticationBuilder = authenticationBuilder;
 
-            ConfigureBankIdHttpClient(httpClient => httpClient.BaseAddress = BankIdUrls.ProdApiBaseUrl);
-            ConfigureBankIdHttpClientHandler(httpClientHandler => httpClientHandler.SslProtocols = SslProtocols.Tls12);
+            ConfigureHttpClient(httpClient => httpClient.BaseAddress = BankIdUrls.ProdApiBaseUrl);
+            ConfigureHttpClientHandler(httpClientHandler => httpClientHandler.SslProtocols = SslProtocols.Tls12);
         }
 
-        public void ConfigureBankIdHttpClient(Action<HttpClient> configureHttpClient)
+        public void ConfigureHttpClient(Action<HttpClient> configureHttpClient)
         {
             _httpClientConfigurators.Add(configureHttpClient);
         }
 
-        public void ConfigureBankIdHttpClientHandler(Action<HttpClientHandler> configureHttpClientHandler)
+        public void ConfigureHttpClientHandler(Action<HttpClientHandler> configureHttpClientHandler)
         {
             _httpClientHandlerConfigurators.Add(configureHttpClientHandler);
         }
 
-        public void EnableBankIdHttpClient()
+        public void EnableHttpClient()
         {
             AuthenticationBuilder.Services.AddHttpClient<IBankIdApiClient, BankIdApiClient>(httpClient =>
                 {

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdAuthenticationBuilderEnvironmentExtensions.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdAuthenticationBuilderEnvironmentExtensions.cs
@@ -11,8 +11,8 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore
             var configuration = new BankIdEnvironmentConfiguration();
             configureBankIdEnvironment(configuration);
 
-            builder.EnableBankIdHttpClient();
-            builder.ConfigureBankIdHttpClient(httpClient =>
+            builder.EnableHttpClient();
+            builder.ConfigureHttpClient(httpClient =>
             {
                 httpClient.BaseAddress = configuration.ApiBaseUrl;
             });

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdAuthenticationBuilderEnvironmentExtensions.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdAuthenticationBuilderEnvironmentExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using ActiveLogin.Authentication.BankId.Api;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace ActiveLogin.Authentication.BankId.AspNetCore
@@ -11,6 +10,8 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore
         {
             var configuration = new BankIdEnvironmentConfiguration();
             configureBankIdEnvironment(configuration);
+
+            builder.EnableBankIdHttpClient();
             builder.ConfigureBankIdHttpClient(httpClient =>
             {
                 httpClient.BaseAddress = configuration.ApiBaseUrl;

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdAuthenticationBuilderExtensions.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdAuthenticationBuilderExtensions.cs
@@ -40,7 +40,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore
 
         public static IBankIdAuthenticationBuilder UseClientCertificate(this IBankIdAuthenticationBuilder builder, Func<X509Certificate2> configureClientCertificate)
         {
-            builder.ConfigureBankIdHttpClientHandler(httpClientHandler =>
+            builder.ConfigureHttpClientHandler(httpClientHandler =>
             {
                 var clientCertificate = configureClientCertificate();
                 httpClientHandler.ClientCertificateOptions = ClientCertificateOption.Manual;
@@ -52,7 +52,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore
 
         public static IBankIdAuthenticationBuilder UseRootCaCertificate(this IBankIdAuthenticationBuilder builder, Func<X509Certificate2> configureRootCaCertificate)
         {
-            builder.ConfigureBankIdHttpClientHandler(httpClientHandler =>
+            builder.ConfigureHttpClientHandler(httpClientHandler =>
             {
                 var rootCaCertificate = configureRootCaCertificate();
                 var validator = new X509CertificateChainValidator(rootCaCertificate);

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/IBankIdAuthenticationBuilder.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/IBankIdAuthenticationBuilder.cs
@@ -10,5 +10,6 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore
 
         void ConfigureBankIdHttpClient(Action<HttpClient> configureHttpClient);
         void ConfigureBankIdHttpClientHandler(Action<HttpClientHandler> configureHttpClientHandler);
+        void EnableBankIdHttpClient();
     }
 }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/IBankIdAuthenticationBuilder.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/IBankIdAuthenticationBuilder.cs
@@ -8,8 +8,8 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore
     {
         AuthenticationBuilder AuthenticationBuilder { get; }
 
-        void ConfigureBankIdHttpClient(Action<HttpClient> configureHttpClient);
-        void ConfigureBankIdHttpClientHandler(Action<HttpClientHandler> configureHttpClientHandler);
-        void EnableBankIdHttpClient();
+        void ConfigureHttpClient(Action<HttpClient> configureHttpClient);
+        void ConfigureHttpClientHandler(Action<HttpClientHandler> configureHttpClientHandler);
+        void EnableHttpClient();
     }
 }

--- a/src/ActiveLogin.Authentication.GrandId.AspNetCore/GrandIdAuthenticationBuilder.cs
+++ b/src/ActiveLogin.Authentication.GrandId.AspNetCore/GrandIdAuthenticationBuilder.cs
@@ -19,8 +19,6 @@ namespace ActiveLogin.Authentication.GrandId.AspNetCore
         {
             AuthenticationBuilder = authenticationBuilder;
 
-            AddHttpClient(AuthenticationBuilder.Services, _httpClientConfigurators, _httpClientHandlerConfigurators);
-
             ConfigureHttpClient(httpClient => httpClient.BaseAddress = GrandIdUrls.ProductionApiBaseUrl);
             ConfigureHttpClientHandler(httpClientHandler => httpClientHandler.SslProtocols = SslProtocols.Tls12);
         }
@@ -35,16 +33,16 @@ namespace ActiveLogin.Authentication.GrandId.AspNetCore
             _httpClientHandlerConfigurators.Add(configureHttpClientHandler);
         }
 
-        private static void AddHttpClient(IServiceCollection services, List<Action<HttpClient>> httpClientConfigurators, List<Action<HttpClientHandler>> httpClientHandlerConfigurators)
+        public void EnableHttpClient()
         {
-            services.AddHttpClient<IGrandIdApiClient, GrandIdApiClient>(httpClient =>
+            AuthenticationBuilder.Services.AddHttpClient<IGrandIdApiClient, GrandIdApiClient>(httpClient =>
                 {
-                    httpClientConfigurators.ForEach(configurator => configurator(httpClient));
+                    _httpClientConfigurators.ForEach(configurator => configurator(httpClient));
                 })
                 .ConfigurePrimaryHttpMessageHandler(() =>
                 {
                     var httpClientHandler = new HttpClientHandler();
-                    httpClientHandlerConfigurators.ForEach(configurator => configurator(httpClientHandler));
+                    _httpClientHandlerConfigurators.ForEach(configurator => configurator(httpClientHandler));
                     return httpClientHandler;
                 });
         }

--- a/src/ActiveLogin.Authentication.GrandId.AspNetCore/GrandIdAuthenticationBuilderEnvironmentExtensions.cs
+++ b/src/ActiveLogin.Authentication.GrandId.AspNetCore/GrandIdAuthenticationBuilderEnvironmentExtensions.cs
@@ -11,6 +11,8 @@ namespace ActiveLogin.Authentication.GrandId.AspNetCore
         {
             var configuration = new GrandIdEnvironmentConfiguration();
             configureGrandIdEnvironment(configuration);
+
+            builder.EnableHttpClient();
             builder.ConfigureHttpClient(httpClient =>
             {
                 httpClient.BaseAddress = configuration.ApiBaseUrl;

--- a/src/ActiveLogin.Authentication.GrandId.AspNetCore/IGrandIdAuthenticationBuilder.cs
+++ b/src/ActiveLogin.Authentication.GrandId.AspNetCore/IGrandIdAuthenticationBuilder.cs
@@ -10,5 +10,6 @@ namespace ActiveLogin.Authentication.GrandId.AspNetCore
 
         void ConfigureHttpClient(Action<HttpClient> configureHttpClient);
         void ConfigureHttpClientHandler(Action<HttpClientHandler> configureHttpClientHandler);
+        void EnableHttpClient();
     }
 }


### PR DESCRIPTION
We did (indirect) register a real implementation of the BankID API as part of registering the HttpClient. Now it's separated and only enabled when calling Test/Prod environments for BankID/GrandID.