### PR TITLE
Normalize the names returned from BankID and GrandID

### DIFF
--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdAuthenticationHandler.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdAuthenticationHandler.cs
@@ -1,11 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using ActiveLogin.Authentication.BankId.AspNetCore.DataProtection;
 using ActiveLogin.Authentication.BankId.AspNetCore.Models;
-using ActiveLogin.Authentication.Common;
 using ActiveLogin.Authentication.Common.Serialization;
 using ActiveLogin.Identity.Swedish;
 using Microsoft.AspNetCore.Authentication;
@@ -88,9 +88,9 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore
             {
                 new Claim(BankIdClaimTypes.Subject, personalIdentityNumber.ToLongString()),
 
-                new Claim(BankIdClaimTypes.Name, loginResult.Name),
-                new Claim(BankIdClaimTypes.FamilyName, loginResult.Surname),
-                new Claim(BankIdClaimTypes.GivenName, loginResult.GivenName),
+                new Claim(BankIdClaimTypes.Name, NormalizeName(loginResult.Name)),
+                new Claim(BankIdClaimTypes.FamilyName, NormalizeName(loginResult.Surname)),
+                new Claim(BankIdClaimTypes.GivenName, NormalizeName(loginResult.GivenName)),
 
                 new Claim(BankIdClaimTypes.SwedishPersonalIdentityNumber, personalIdentityNumber.ToShortString())
             };
@@ -98,6 +98,11 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore
             AddOptionalClaims(claims, personalIdentityNumber, expiresUtc);
 
             return claims;
+        }
+
+        private string NormalizeName(string name)
+        {
+            return Options.NormalizeNames ? CultureInfo.CurrentCulture.TextInfo.ToTitleCase(name.ToLowerInvariant()) : name;
         }
 
         private void AddOptionalClaims(List<Claim> claims, SwedishPersonalIdentityNumber personalIdentityNumber, DateTimeOffset? expiresUtc)

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdAuthenticationHandler.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdAuthenticationHandler.cs
@@ -102,7 +102,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore
 
         private string NormalizeName(string name)
         {
-            return Options.NormalizeNames ? CultureInfo.CurrentCulture.TextInfo.ToTitleCase(name.ToLowerInvariant()) : name;
+            return Options.NormalizePersonNameCapitalization ? CultureInfo.CurrentCulture.TextInfo.ToTitleCase(name.ToLowerInvariant()) : name;
         }
 
         private void AddOptionalClaims(List<Claim> claims, SwedishPersonalIdentityNumber personalIdentityNumber, DateTimeOffset? expiresUtc)

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdAuthenticationOptions.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdAuthenticationOptions.cs
@@ -51,6 +51,8 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore
         public bool IssueGenderClaim { get; set; } = true;
         public bool IssueBirthdateClaim { get; set; } = true;
 
+        public bool NormalizeNames { get; set; }
+
         public ISecureDataFormat<BankIdState> StateDataFormat { get; set; }
 
         public CookieBuilder StateCookie

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdAuthenticationOptions.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdAuthenticationOptions.cs
@@ -51,7 +51,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore
         public bool IssueGenderClaim { get; set; } = true;
         public bool IssueBirthdateClaim { get; set; } = true;
 
-        public bool NormalizeNames { get; set; }
+        public bool NormalizePersonNameCapitalization { get; set; }
 
         public ISecureDataFormat<BankIdState> StateDataFormat { get; set; }
 

--- a/src/ActiveLogin.Authentication.GrandId.AspNetCore/GrandIdAuthenticationHandler.cs
+++ b/src/ActiveLogin.Authentication.GrandId.AspNetCore/GrandIdAuthenticationHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
@@ -92,9 +93,9 @@ namespace ActiveLogin.Authentication.GrandId.AspNetCore
             {
                 new Claim(GrandIdClaimTypes.Subject, personalIdentityNumber.ToLongString()),
 
-                new Claim(GrandIdClaimTypes.Name, loginResult.UserAttributes.Name),
-                new Claim(GrandIdClaimTypes.FamilyName, loginResult.UserAttributes.Surname),
-                new Claim(GrandIdClaimTypes.GivenName, loginResult.UserAttributes.GivenName),
+                new Claim(GrandIdClaimTypes.Name, NormalizeName(loginResult.UserAttributes.Name)),
+                new Claim(GrandIdClaimTypes.FamilyName, NormalizeName(loginResult.UserAttributes.Surname)),
+                new Claim(GrandIdClaimTypes.GivenName, NormalizeName(loginResult.UserAttributes.GivenName)),
 
                 new Claim(GrandIdClaimTypes.SwedishPersonalIdentityNumber, personalIdentityNumber.ToShortString())
             };
@@ -102,6 +103,11 @@ namespace ActiveLogin.Authentication.GrandId.AspNetCore
             AddOptionalClaims(claims, personalIdentityNumber, expiresUtc);
 
             return claims;
+        }
+
+        private string NormalizeName(string name)
+        {
+            return Options.NormalizePersonNameCapitalization ? CultureInfo.CurrentCulture.TextInfo.ToTitleCase(name.ToLowerInvariant()) : name;
         }
 
         private void AddOptionalClaims(List<Claim> claims, SwedishPersonalIdentityNumber personalIdentityNumber, DateTimeOffset? expiresUtc)

--- a/src/ActiveLogin.Authentication.GrandId.AspNetCore/GrandIdAuthenticationOptions.cs
+++ b/src/ActiveLogin.Authentication.GrandId.AspNetCore/GrandIdAuthenticationOptions.cs
@@ -42,6 +42,8 @@ namespace ActiveLogin.Authentication.GrandId.AspNetCore
             set => _stateCookieBuilder = value ?? throw new ArgumentNullException(nameof(value));
         }
 
+        public bool NormalizePersonNameCapitalization { get; set; }
+
         public override void Validate()
         {
             base.Validate();


### PR DESCRIPTION
I did not put the shared method to Common since this is a PoC with ToTitleCase with only one row, otherwise it creates to much over code to instantiate the helper based on Options.