### PR TITLE
Siths support

### DIFF
--- a/src/ActiveLogin.Authentication.GrandId.Api/Models/SessionUserAttributes.cs
+++ b/src/ActiveLogin.Authentication.GrandId.Api/Models/SessionUserAttributes.cs
@@ -28,5 +28,20 @@ namespace ActiveLogin.Authentication.GrandId.Api.Models
 
         [DataMember(Name = "ipAddress")]
         public string IpAddress { get; set; }
+
+        [DataMember(Name = "serialNumber")]
+        public string SerialNumber { get; set; }
+
+        [DataMember(Name = "firstname")]
+        public string FirstName { get; set; }
+
+        [DataMember(Name = "lastname")]
+        public string LastName { get; set; }
+
+        [DataMember(Name = "clientCertificateSerial")]
+        public string ClientCertificateSerial { get; set; }
+
+        [DataMember(Name = "DN_Email")]
+        public string Email { get; set; }
     }
 }

--- a/src/ActiveLogin.Authentication.GrandId.AspNetCore/GrandIdAuthenticationDefaults.cs
+++ b/src/ActiveLogin.Authentication.GrandId.AspNetCore/GrandIdAuthenticationDefaults.cs
@@ -17,6 +17,10 @@ namespace ActiveLogin.Authentication.GrandId.AspNetCore
         public const string ChooseDeviceDisplayName = "BankID";
         public static readonly PathString ChooseDeviceCallpackPath = new PathString("/signin-grandid-choosedevice");
 
+        public const string SithsAuthenticationScheme = "grandid-siths";
+        public const string SithsDisplayName = "Siths";
+        public static readonly PathString SithsCallpackPath = new PathString("/signin-grandid-siths");
+
         public const string IdentityProviderName = "GrandId";
         public const string AuthenticationMethodName = "grandid";
 

--- a/src/ActiveLogin.Authentication.GrandId.AspNetCore/GrandIdAuthenticationOptions.cs
+++ b/src/ActiveLogin.Authentication.GrandId.AspNetCore/GrandIdAuthenticationOptions.cs
@@ -22,7 +22,6 @@ namespace ActiveLogin.Authentication.GrandId.AspNetCore
         /// AuthenticateServiceKey obtained from GrandID (Svensk E-identitet).
         /// </summary>
         public string GrandIdAuthenticateServiceKey { get; set; }
-
         public TimeSpan? TokenExpiresIn { get; set; } = GrandIdAuthenticationDefaults.MaximumSessionLifespan;
 
         public bool IssueAuthenticationMethodClaim { get; set; } = true;
@@ -33,7 +32,7 @@ namespace ActiveLogin.Authentication.GrandId.AspNetCore
 
         public bool IssueGenderClaim { get; set; } = true;
         public bool IssueBirthdateClaim { get; set; } = true;
-
+        public bool UseSiths { get; set; } = false;
         public ISecureDataFormat<GrandIdState> StateDataFormat { get; set; }
 
         public CookieBuilder StateCookie


### PR DESCRIPTION
Lesser used "device" within GrandId.

Library threw exception when trying to parse and empty social security number - which is not an included claim when authenticating with Siths.

Also added the userAttributes from this flow/response. 