### PR TITLE
Do not use AutoLaunch for dev environment

### DIFF
--- a/samples/Standalone.MvcSample/Standalone.MvcSample.csproj
+++ b/samples/Standalone.MvcSample/Standalone.MvcSample.csproj
@@ -7,7 +7,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="ActiveLogin.Authentication.BankId.AspNetCore" Version="1.0.0-rc-1" />
+    <PackageReference Include="ActiveLogin.Authentication.BankId.AspNetCore" Version="1.0.0-rc-2" />
     <PackageReference Include="ActiveLogin.Authentication.BankId.AspNetCore.Azure" Version="1.0.0-rc-1" />
     <PackageReference Include="ActiveLogin.Authentication.GrandId.AspNetCore" Version="1.0.0-rc-1" />
     <PackageReference Include="Microsoft.AspNetCore.App" />

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Controllers/BankIdApiController.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Controllers/BankIdApiController.cs
@@ -103,7 +103,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthenticatio
 
             _logger.BankIdAuthSuccess(personalIdentityNumber, orderRef);
 
-            if (unprotectedLoginOptions.AutoLaunch)
+            if (unprotectedLoginOptions.AutoLaunch && _bankIdLauncher.CanLaunch)
             {
                 var detectedDevice = _bankIdSupportedDeviceDetector.Detect(HttpContext.Request.Headers["User-Agent"]);
                 var bankIdRedirectUri = GetBankIdRedirectUri(request, protectedOrderRef, authResponse, detectedDevice);

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdDevelopmentLauncher.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdDevelopmentLauncher.cs
@@ -8,5 +8,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore
         {
             return request.RedirectUrl;
         }
+
+        public bool CanLaunch => false;
     }
 }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdLauncher.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdLauncher.cs
@@ -17,6 +17,8 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore
             return $"{prefix}{queryString}";
         }
 
+        public bool CanLaunch => true;
+
         private string GetPrefixPart(BankIdSupportedDevice device)
         {
             if (device.IsIos)

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/IBankIdLauncher.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/IBankIdLauncher.cs
@@ -5,5 +5,6 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore
     public interface IBankIdLauncher
     {
         string GetLaunchUrl(BankIdSupportedDevice device, LaunchUrlRequest request);
+        bool CanLaunch { get; }
     }
 }


### PR DESCRIPTION
This is a fix for #68 .
We can even later on use that property `CanLaunch` if someone wants to do like a JS or native verification that BankID app is installed...