### PR TITLE
Add validation of AntiforgeryToken in the samples

### DIFF
--- a/samples/IdentityServer.ClientSample/Startup.cs
+++ b/samples/IdentityServer.ClientSample/Startup.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Authorization;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -28,6 +29,8 @@ namespace IdentityServer.ClientSample
                     .Build();
 
                 config.Filters.Add(new AuthorizeFilter(policy));
+
+                config.Filters.Add(new AutoValidateAntiforgeryTokenAttribute());
             });
 
             JwtSecurityTokenHandler.DefaultInboundClaimTypeMap.Clear();

--- a/samples/IdentityServer.ServerSample/Startup.cs
+++ b/samples/IdentityServer.ServerSample/Startup.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.CookiePolicy;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Localization;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -46,7 +47,10 @@ namespace IdentityServer.ServerSample
                 options.Secure = CookieSecurePolicy.Always;
             });
 
-            services.AddMvc();
+            services.AddMvc(config =>
+            {
+                config.Filters.Add(new AutoValidateAntiforgeryTokenAttribute());
+            });
 
             services.AddIdentityServer(x => { x.Authentication.CookieLifetime = TimeSpan.FromHours(1); })
                     .AddDeveloperSigningCredential()

--- a/samples/Standalone.MvcSample/Startup.cs
+++ b/samples/Standalone.MvcSample/Startup.cs
@@ -76,7 +76,11 @@ namespace Standalone.MvcSample
                     }
                 });
 
-            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
+            services.AddMvc(config =>
+            {
+                config.Filters.Add(new AutoValidateAntiforgeryTokenAttribute());
+            })
+            .SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
         }
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)


### PR DESCRIPTION
We did not validate the AntiforgeryToken when doing logout. The samples are now updated with a policy to always require it when relevant.