### PR TITLE
Add SonarCloud badges and fix bugs found

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ ActiveLogin.Authentication enables an application to support Swedish BankID's (s
 
 [![Build status](https://dev.azure.com/activesolution/ActiveLogin/_apis/build/status/ActiveLogin.Authentication)](https://dev.azure.com/activesolution/ActiveLogin/_build/latest?definitionId=155)
 
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=ActiveLogin_ActiveLogin.Authentication&metric=alert_status)](https://sonarcloud.io/dashboard?id=ActiveLogin_ActiveLogin.Authentication)
+
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=ActiveLogin_ActiveLogin.Authentication&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=ActiveLogin_ActiveLogin.Authentication)
+
 | Project | Description | NuGet |
 | ------- | ----------- | ----- |
 | [ActiveLogin.Authentication.BankId.Api](https://github.com/ActiveLogin/ActiveLogin.Authentication/tree/master/src/ActiveLogin.Authentication.BankId.Api) | API client for Swedish BankID's REST API. | [![NuGet](https://img.shields.io/nuget/v/ActiveLogin.Authentication.BankId.Api.svg)](https://www.nuget.org/packages/ActiveLogin.Authentication.BankId.Api/) |

--- a/README.md
+++ b/README.md
@@ -14,11 +14,7 @@ ActiveLogin.Authentication enables an application to support Swedish BankID's (s
 
 ## Continuous integration & Packages overview
 
-[![Build status](https://dev.azure.com/activesolution/ActiveLogin/_apis/build/status/ActiveLogin.Authentication)](https://dev.azure.com/activesolution/ActiveLogin/_build/latest?definitionId=155)
-
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=ActiveLogin_ActiveLogin.Authentication&metric=alert_status)](https://sonarcloud.io/dashboard?id=ActiveLogin_ActiveLogin.Authentication)
-
-[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=ActiveLogin_ActiveLogin.Authentication&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=ActiveLogin_ActiveLogin.Authentication)
+[![Build status](https://dev.azure.com/activesolution/ActiveLogin/_apis/build/status/ActiveLogin.Authentication)](https://dev.azure.com/activesolution/ActiveLogin/_build/latest?definitionId=155) [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=ActiveLogin_ActiveLogin.Authentication&metric=alert_status)](https://sonarcloud.io/dashboard?id=ActiveLogin_ActiveLogin.Authentication) [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=ActiveLogin_ActiveLogin.Authentication&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=ActiveLogin_ActiveLogin.Authentication)
 
 | Project | Description | NuGet |
 | ------- | ----------- | ----- |

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Controllers/BankIdApiController.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Controllers/BankIdApiController.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
@@ -123,9 +124,14 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthenticatio
         private AuthRequest GetAuthRequest(SwedishPersonalIdentityNumber personalIdentityNumber, BankIdLoginOptions loginOptions)
         {
             var endUserIp = GetEndUserIp();
-            var certificatePolicies = loginOptions.CertificatePolicies?.Any() ?? false ? loginOptions.CertificatePolicies : null;
             var personalIdentityNumberString = personalIdentityNumber?.To12DigitString();
             var autoStartTokenRequired = string.IsNullOrEmpty(personalIdentityNumberString) ? true : (bool?)null;
+
+            List<string> certificatePolicies = null;
+            if (loginOptions.CertificatePolicies != null && loginOptions.CertificatePolicies.Any())
+            {
+                certificatePolicies = loginOptions.CertificatePolicies;
+            }
 
             var authRequestRequirement = new Requirement(certificatePolicies, autoStartTokenRequired, loginOptions.AllowBiometric);
 

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdClaimTypes.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdClaimTypes.cs
@@ -16,6 +16,6 @@
         public const string Gender = "gender";
         public const string Birthdate = "birthdate";
 
-        public static string SwedishPersonalIdentityNumber = "swedish_personal_identity_number";
+        public const string SwedishPersonalIdentityNumber = "swedish_personal_identity_number";
     }
 }

--- a/src/ActiveLogin.Authentication.GrandId.AspNetCore/GrandIdClaimTypes.cs
+++ b/src/ActiveLogin.Authentication.GrandId.AspNetCore/GrandIdClaimTypes.cs
@@ -16,6 +16,6 @@
         public const string Gender = "gender";
         public const string Birthdate = "birthdate";
 
-        public static string SwedishPersonalIdentityNumber = "swedish_personal_identity_number";
+        public const string SwedishPersonalIdentityNumber = "swedish_personal_identity_number";
     }
 }


### PR DESCRIPTION
Adds badges for our SonarCube/SonarCloud scan (https://sonarcloud.io/dashboard?id=ActiveLogin_ActiveLogin.Authentication).
Also fixes three things found
- Public static properties that should be constants
- Simplier syntax for setting cert policies to not hit bug report