### PR TITLE
Added Http method on action

### DIFF
--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Controllers/BankIdController.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Controllers/BankIdController.cs
@@ -34,6 +34,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthenticatio
             _localizer = localizer;
         }
     
+        [HttpGet]
         public ActionResult Login(string returnUrl, string loginOptions)
         {
             if (!Url.IsLocalUrl(returnUrl))


### PR DESCRIPTION
This is required in Swagger 2.0.

Yes, We know this is intended for a web, but we are evaluating it for our backend api.

Error message:
```
System.NotSupportedException: 'Ambiguous HTTP method for action - ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthentication.Controllers.BankIdController.Login (ActiveLogin.Authentication.BankId.AspNetCore). Actions require an explicit HttpMethod binding for Swagger 2.0'
```

Fixes #121.