### PR TITLE
Add use authorization to support IdentityServer controller

### DIFF
--- a/samples/IdentityServer.ServerSample/Startup.cs
+++ b/samples/IdentityServer.ServerSample/Startup.cs
@@ -159,6 +159,7 @@ namespace IdentityServer.ServerSample
             app.UseCookiePolicy();
             app.UseRouting();
 
+            app.UseAuthorization();
             app.UseIdentityServer();
 
             app.UseRequestLocalization(options =>


### PR DESCRIPTION
The identity server example was broken by 3.0 update. This fixes the issue by adding authorization to the pipeline since it is required by identityserver.

Ref #131 