### PR TITLE
Add cancel button to abort BankID auth requests

### DIFF
--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Controllers/BankIdApiController.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Controllers/BankIdApiController.cs
@@ -262,5 +262,17 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthenticatio
             var delimiter = url.Contains("?") ? "&" : "?";
             return $"{url}{delimiter}{queryString}";
         }
+
+        [ValidateAntiForgeryToken]
+        [HttpPost("Cancel")]
+        public async Task<CancelResponse> Cancel(BankIdCancelApiStatusRequest request)
+        {
+            var orderRef = _orderRefProtector.Unprotect(request.OrderRef);
+            var result = await _bankIdApiClient.CancelAsync(orderRef.OrderRef);
+
+            _logger.BankIdAuthCancelled(orderRef.OrderRef);
+
+            return result;
+        }
     }
 }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Controllers/BankIdApiController.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Controllers/BankIdApiController.cs
@@ -265,14 +265,15 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthenticatio
 
         [ValidateAntiForgeryToken]
         [HttpPost("Cancel")]
-        public async Task<CancelResponse> Cancel(BankIdCancelApiStatusRequest request)
+        public async Task<ActionResult> Cancel(BankIdLoginApiCancelRequest request)
         {
             var orderRef = _orderRefProtector.Unprotect(request.OrderRef);
-            var result = await _bankIdApiClient.CancelAsync(orderRef.OrderRef);
+
+            await _bankIdApiClient.CancelAsync(orderRef.OrderRef);
 
             _logger.BankIdAuthCancelled(orderRef.OrderRef);
 
-            return result;
+            return Ok(BankIdLoginApiCancelResponse.Cancelled());
         }
     }
 }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Controllers/BankIdController.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Controllers/BankIdController.cs
@@ -33,7 +33,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthenticatio
             _loginOptionsProtector = loginOptionsProtector;
             _localizer = localizer;
         }
-    
+
         [HttpGet]
         public ActionResult Login(string returnUrl, string loginOptions)
         {
@@ -48,7 +48,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthenticatio
             var viewModel = GetLoginViewModel(returnUrl, loginOptions, unprotectedLoginOptions, antiforgeryTokens);
             return View(viewModel);
         }
-        
+
         private BankIdLoginViewModel GetLoginViewModel(string returnUrl, string loginOptions, BankIdLoginOptions unprotectedLoginOptions, AntiforgeryTokenSet antiforgeryTokens)
         {
             var loginScriptOptions = new BankIdLoginScriptOptions
@@ -61,7 +61,8 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthenticatio
                 UnsupportedBrowserErrorMessage = _localizer["UnsupportedBrowser_ErrorMessage"],
 
                 BankIdInitializeApiUrl = Url.Action("Initialize", "BankIdApi"),
-                BankIdStatusApiUrl = Url.Action("Status", "BankIdApi")
+                BankIdStatusApiUrl = Url.Action("Status", "BankIdApi"),
+                BankIdCancelApiUrl = Url.Action("Cancel", "BankIdApi")
             };
 
             return new BankIdLoginViewModel

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Models/BankIdCancelApiStatusRequest.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Models/BankIdCancelApiStatusRequest.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthentication.Models
+{
+    public class BankIdCancelApiStatusRequest
+    {
+        internal BankIdCancelApiStatusRequest()
+        {
+
+        }
+
+        [Required]
+        public string OrderRef { get; set; }
+
+    }
+}

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Models/BankIdLoginApiCancelRequest.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Models/BankIdLoginApiCancelRequest.cs
@@ -2,9 +2,9 @@ using System.ComponentModel.DataAnnotations;
 
 namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthentication.Models
 {
-    public class BankIdCancelApiStatusRequest
+    public class BankIdLoginApiCancelRequest
     {
-        internal BankIdCancelApiStatusRequest()
+        internal BankIdLoginApiCancelRequest()
         {
 
         }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Models/BankIdLoginApiCancelResponse.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Models/BankIdLoginApiCancelResponse.cs
@@ -1,0 +1,15 @@
+namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthentication.Models
+{
+    public class BankIdLoginApiCancelResponse
+    {
+        internal BankIdLoginApiCancelResponse()
+        {
+
+        }
+
+        public static BankIdLoginApiCancelResponse Cancelled()
+        {
+            return new BankIdLoginApiCancelResponse();
+        }
+    }
+}

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Models/BankIdLoginScriptOptions.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Models/BankIdLoginScriptOptions.cs
@@ -8,7 +8,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthenticatio
     {
         internal BankIdLoginScriptOptions()
         {
-            
+
         }
 
         private const int MinimumRefreshIntervalMs = 1000;
@@ -34,6 +34,9 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthenticatio
 
         [DataMember(Name = "bankIdStatusApiUrl")]
         public string BankIdStatusApiUrl { get; set; }
+
+        [DataMember(Name = "bankIdCancelApiUrl")]
+        public string BankIdCancelApiUrl { get; set; }
 
         [DataMember(Name = "initialStatusMessage")]
         public string InitialStatusMessage { get; set; } = string.Empty;

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Views/BankId/_LoginScript.cshtml
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Views/BankId/_LoginScript.cshtml
@@ -121,11 +121,11 @@
                             checkStatus(requestVerificationToken, returnUrl, loginOptions, data.orderRef);
                         }
 
-                        cancelButtonElement.addEventListener('click', function (event) {
-                            event.preventDefault();
+                        var onCancelButtonClick = function(event) {
                             cancel(requestVerificationToken, data.orderRef);
-                            cancelButtonElement.onclick = undefined;
-                        });
+                            event.target.removeEventListener('click', onCancelButtonClick);
+                        };
+                        cancelButtonElement.addEventListener('click', onCancelButtonClick);
                     }
                     show(formSubmitButtonTextElement);
                     hide(formSubmitButtonSpinnerElement);

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Views/BankId/_LoginScript.cshtml
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Views/BankId/_LoginScript.cshtml
@@ -80,7 +80,7 @@
 
         // BankID
 
-        var loginIsCancelledByUser;
+        var loginIsCancelledByUser = false;
         function initialize(requestVerificationToken, returnUrl, loginOptions, personalIdentityNumber, personalIdentityNumberElement) {
             loginIsCancelledByUser = false;
             formFieldsetElement.disabled = true;

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Views/BankId/_LoginScript.cshtml
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Views/BankId/_LoginScript.cshtml
@@ -4,8 +4,10 @@
     (function (options) {
         // Pre check
         var statusElement = document.querySelector('#bankIdLoginStatus');
+        var statusCardElement = statusElement.querySelector('.card');
         var statusSpinnerElement = statusElement.querySelector('.status-spinner');
         var statusMessageElement = statusElement.querySelector('.status-message');
+        var cancelButtonElement = statusElement.querySelector('.btn-cancel');
 
         var requiredFeatures = [window.fetch, window.sessionStorage];
         var isMissingSomeFeature = requiredFeatures.some(function(x) { return !x; });
@@ -78,7 +80,9 @@
 
         // BankID
 
+        var cancelled;
         function initialize(requestVerificationToken, returnUrl, loginOptions, personalIdentityNumber, personalIdentityNumberElement) {
+            cancelled = false;
             formFieldsetElement.disabled = true;
             show(formSubmitButtonSpinnerElement);
             hide(formSubmitButtonTextElement);
@@ -116,6 +120,12 @@
                         if (data.checkStatus) {
                             checkStatus(requestVerificationToken, returnUrl, loginOptions, data.orderRef);
                         }
+
+                        cancelButtonElement.onclick = function(e) {
+                            e.preventDefault();
+                            cancel(requestVerificationToken, returnUrl, loginOptions, data.orderRef);
+                            cancelButtonElement.onclick = undefined;
+                        };
                     }
                     show(formSubmitButtonTextElement);
                     hide(formSubmitButtonSpinnerElement);
@@ -126,6 +136,21 @@
                     hide(formSubmitButtonSpinnerElement);
                     formFieldsetElement.disabled = false;
                 });
+        }
+
+        function cancel(requestVerificationToken, returnUrl, loginOptions, orderRef) {
+            cancelled = true;
+            postJson(options.bankIdCancelApiUrl, requestVerificationToken, {
+                'orderRef': orderRef
+            }).then(function() {
+                hide(statusElement);
+                show(formElement);
+                formFieldsetElement.disabled = false;
+            }).catch(function(error) {
+                showStatus(error.message, 'danger', false);
+                hide(startBankIdAppButtonElement);
+                hide(cancelButtonElement);
+            });
         }
 
         function checkStatus(requestVerificationToken, returnUrl, loginOptions, orderRef) {
@@ -139,12 +164,14 @@
                     if (data.isFinished) {
                         window.location.href = data.redirectUri;
                     } else {
+                        if (cancelled) return;
                         showStatus(data.statusMessage, 'light', true);
                         setTimeout(function () {
                             checkStatus(requestVerificationToken, returnUrl, loginOptions, orderRef);
                         }, options.refreshIntervalMs);
                     }
                 }).catch(function (error) {
+                    if (cancelled) return;
                     showStatus(error.message, 'danger', false);
                     hide(startBankIdAppButtonElement);
                 });
@@ -186,7 +213,7 @@
                 textClass = '';
             }
 
-            statusElement.className = 'card bg-' + type + ' ' + textClass;
+            statusCardElement.className = 'card bg-' + type + ' ' + textClass;
             if (!!html) {
                 statusMessageElement.innerHTML = status;
             } else {

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Views/BankId/_LoginScript.cshtml
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Views/BankId/_LoginScript.cshtml
@@ -4,7 +4,7 @@
     (function (options) {
         // Pre check
         var statusElement = document.querySelector('#bankIdLoginStatus');
-        var statusCardElement = statusElement.querySelector('.card');
+        var statusWrapperElement = statusElement.querySelector('.status-wrapper');
         var statusSpinnerElement = statusElement.querySelector('.status-spinner');
         var statusMessageElement = statusElement.querySelector('.status-message');
         var cancelButtonElement = statusElement.querySelector('.btn-cancel');
@@ -80,9 +80,9 @@
 
         // BankID
 
-        var cancelled;
+        var loginIsCancelledByUser;
         function initialize(requestVerificationToken, returnUrl, loginOptions, personalIdentityNumber, personalIdentityNumberElement) {
-            cancelled = false;
+            loginIsCancelledByUser = false;
             formFieldsetElement.disabled = true;
             show(formSubmitButtonSpinnerElement);
             hide(formSubmitButtonTextElement);
@@ -121,11 +121,11 @@
                             checkStatus(requestVerificationToken, returnUrl, loginOptions, data.orderRef);
                         }
 
-                        cancelButtonElement.onclick = function(e) {
-                            e.preventDefault();
-                            cancel(requestVerificationToken, returnUrl, loginOptions, data.orderRef);
+                        cancelButtonElement.addEventListener('click', function (event) {
+                            event.preventDefault();
+                            cancel(requestVerificationToken, data.orderRef);
                             cancelButtonElement.onclick = undefined;
-                        };
+                        });
                     }
                     show(formSubmitButtonTextElement);
                     hide(formSubmitButtonSpinnerElement);
@@ -138,8 +138,8 @@
                 });
         }
 
-        function cancel(requestVerificationToken, returnUrl, loginOptions, orderRef) {
-            cancelled = true;
+        function cancel(requestVerificationToken, orderRef) {
+            loginIsCancelledByUser = true;
             postJson(options.bankIdCancelApiUrl, requestVerificationToken, {
                 'orderRef': orderRef
             }).then(function() {
@@ -163,17 +163,17 @@
                 .then(function (data) {
                     if (data.isFinished) {
                         window.location.href = data.redirectUri;
-                    } else {
-                        if (cancelled) return;
+                    } else if(!loginIsCancelledByUser) {
                         showStatus(data.statusMessage, 'light', true);
                         setTimeout(function () {
                             checkStatus(requestVerificationToken, returnUrl, loginOptions, orderRef);
                         }, options.refreshIntervalMs);
                     }
                 }).catch(function (error) {
-                    if (cancelled) return;
-                    showStatus(error.message, 'danger', false);
-                    hide(startBankIdAppButtonElement);
+                    if (!loginIsCancelledByUser) {
+                        showStatus(error.message, 'danger', false);
+                        hide(startBankIdAppButtonElement);
+                    }
                 });
         }
 
@@ -213,7 +213,7 @@
                 textClass = '';
             }
 
-            statusCardElement.className = 'card bg-' + type + ' ' + textClass;
+            statusWrapperElement.className = 'card status-wrapper bg-' + type + ' ' + textClass;
             if (!!html) {
                 statusMessageElement.innerHTML = status;
             } else {

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Views/BankId/_LoginScript.cshtml
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Views/BankId/_LoginScript.cshtml
@@ -163,7 +163,7 @@
                 .then(function (data) {
                     if (data.isFinished) {
                         window.location.href = data.redirectUri;
-                    } else if(!loginIsCancelledByUser) {
+                    } else if (!loginIsCancelledByUser) {
                         showStatus(data.statusMessage, 'light', true);
                         setTimeout(function () {
                             checkStatus(requestVerificationToken, returnUrl, loginOptions, orderRef);

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Views/BankId/_LoginStatus.cshtml
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Views/BankId/_LoginStatus.cshtml
@@ -2,13 +2,20 @@
 @model ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthentication.Models.BankIdLoginViewModel
 @inject IStringLocalizer<ActiveLogin.Authentication.BankId.AspNetCore.BankIdAuthenticationHandler> Localizer
 
-<div class="card" id="bankIdLoginStatus" style="display: @(Model.AutoLogin ? "block" : "none");">
-    <div class="card-body">
-        <div class="status-spinner">
-            <partial name="_spinner" />
+
+<div id="bankIdLoginStatus" style="display: @(Model.AutoLogin ? "block" : "none");">
+    <div class="card">
+        <div class="card-body">
+            <div class="status-spinner">
+                <partial name="_spinner" />
+            </div>
+            <div class="status-message">@Model.LoginScriptOptions.InitialStatusMessage</div>
         </div>
-        <div class="status-message">@Model.LoginScriptOptions.InitialStatusMessage</div>
     </div>
+
+    <button type="button" class="btn btn-danger btn-block btn-cancel mt-2">
+        @Localizer["Cancel_Button"]
+    </button>
 </div>
 
 <button id="bankIdLoginStartApp" type="button" class="btn btn-primary btn-block mt-2" style="display: none;">

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Views/BankId/_LoginStatus.cshtml
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Views/BankId/_LoginStatus.cshtml
@@ -4,7 +4,7 @@
 
 
 <div id="bankIdLoginStatus" style="display: @(Model.AutoLogin ? "block" : "none");">
-    <div class="card">
+    <div class="card status-wrapper">
         <div class="card-body">
             <div class="status-spinner">
                 <partial name="_spinner" />
@@ -13,7 +13,7 @@
         </div>
     </div>
 
-    <button type="button" class="btn btn-danger btn-block btn-cancel mt-2">
+    <button type="button" class="btn btn-link btn-block btn-cancel mt-2">
         @Localizer["Cancel_Button"]
     </button>
 </div>

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdLoggingEvents.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdLoggingEvents.cs
@@ -10,7 +10,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore
         // BankId API - Auth
         public static readonly EventId BankIdAuthSuccess = new EventId(2_1_1, nameof(BankIdAuthSuccess));
         public static readonly EventId BankIdAuthHardFailure = new EventId(2_1_2, nameof(BankIdAuthHardFailure));
-        public static readonly EventId BankIdAuthHardCancel = new EventId(2_1_3, nameof(BankIdAuthHardCancel));
+        public static readonly EventId BankIdAuthCancel = new EventId(2_1_3, nameof(BankIdAuthCancel));
 
         // BankId API - Collect
         public static readonly EventId BankIdCollectSoftFailure = new EventId(2_2_2, nameof(BankIdCollectSoftFailure));

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdLoggingEvents.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdLoggingEvents.cs
@@ -10,6 +10,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore
         // BankId API - Auth
         public static readonly EventId BankIdAuthSuccess = new EventId(2_1_1, nameof(BankIdAuthSuccess));
         public static readonly EventId BankIdAuthHardFailure = new EventId(2_1_2, nameof(BankIdAuthHardFailure));
+        public static readonly EventId BankIdAuthHardCancel = new EventId(2_1_3, nameof(BankIdAuthHardCancel));
 
         // BankId API - Collect
         public static readonly EventId BankIdCollectSoftFailure = new EventId(2_2_2, nameof(BankIdCollectSoftFailure));

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/LoggerExtensions.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/LoggerExtensions.cs
@@ -31,6 +31,11 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore
             logger.LogTrace(BankIdLoggingEvents.BankIdAuthSuccess, "BankID auth succedded for PersonalIdentityNumber '{PersonalIdentityNumber}' with the OrderRef '{OrderRef}'", personalIdentityNumber?.To12DigitString() ?? MissingPersonalIdentityNumber, orderRef);
         }
 
+        public static void BankIdAuthCancelled(this ILogger logger, string orderRef)
+        {
+            logger.LogInformation(BankIdLoggingEvents.BankIdAuthSuccess, "BankID auth was cancelled with the OrderRef '{OrderRef}'", orderRef);
+        }
+
         // BankID API - Collect
 
         public static void BankIdCollectFailure(this ILogger logger, string orderRef, BankIdApiException bankIdApiException)

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/LoggerExtensions.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/LoggerExtensions.cs
@@ -33,7 +33,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore
 
         public static void BankIdAuthCancelled(this ILogger logger, string orderRef)
         {
-            logger.LogInformation(BankIdLoggingEvents.BankIdAuthSuccess, "BankID auth was cancelled with the OrderRef '{OrderRef}'", orderRef);
+            logger.LogInformation(BankIdLoggingEvents.BankIdAuthHardCancel, "BankID auth was cancelled with the OrderRef '{OrderRef}'", orderRef);
         }
 
         // BankID API - Collect

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/LoggerExtensions.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/LoggerExtensions.cs
@@ -33,7 +33,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore
 
         public static void BankIdAuthCancelled(this ILogger logger, string orderRef)
         {
-            logger.LogInformation(BankIdLoggingEvents.BankIdAuthHardCancel, "BankID auth was cancelled with the OrderRef '{OrderRef}'", orderRef);
+            logger.LogInformation(BankIdLoggingEvents.BankIdAuthCancel, "BankID auth was cancelled with the OrderRef '{OrderRef}'", orderRef);
         }
 
         // BankID API - Collect

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Resources/BankIdAuthenticationHandler.Designer.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Resources/BankIdAuthenticationHandler.Designer.cs
@@ -296,6 +296,15 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cancel.
+        /// </summary>
+        internal static string Cancel_Button {
+            get {
+                return ResourceManager.GetString("Cancel_Button", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Your browser does not have the features required to use this login page..
         /// </summary>
         internal static string UnsupportedBrowser_ErrorMessage {

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Resources/BankIdAuthenticationHandler.resx
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Resources/BankIdAuthenticationHandler.resx
@@ -195,6 +195,9 @@
   <data name="SignIn_Title" xml:space="preserve">
     <value>Sign in with BankID</value>
   </data>
+  <data name="Cancel_Button" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
   <data name="UnsupportedBrowser_ErrorMessage" xml:space="preserve">
     <value>Your browser does not have the features required to use this login page.</value>
   </data>

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Resources/BankIdAuthenticationHandler.sv.resx
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Resources/BankIdAuthenticationHandler.sv.resx
@@ -195,6 +195,9 @@
   <data name="SignIn_Title" xml:space="preserve">
     <value>Logga in med BankID</value>
   </data>
+  <data name="Cancel_Button" xml:space="preserve">
+    <value>Avbryt</value>
+  </data>
   <data name="UnsupportedBrowser_ErrorMessage" xml:space="preserve">
     <value>Din webbläsare saknar funktioner som krävs för att använda denna loginsida.</value>
   </data>

--- a/test/ActiveLogin.Authentication.BankId.AspNetCore.Test/BankId_Authentication_Tests.cs
+++ b/test/ActiveLogin.Authentication.BankId.AspNetCore.Test/BankId_Authentication_Tests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.TestHost;
@@ -6,14 +6,15 @@ using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
+using ActiveLogin.Authentication.BankId.Api;
 using ActiveLogin.Authentication.BankId.AspNetCore.DataProtection;
 using ActiveLogin.Authentication.BankId.AspNetCore.Launcher;
 using ActiveLogin.Authentication.BankId.AspNetCore.Models;
 using ActiveLogin.Authentication.BankId.AspNetCore.Test.Helpers;
-using ActiveLogin.Identity.Swedish;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -22,6 +23,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Moq;
 using Newtonsoft.Json;
 using Xunit;
+using ActiveLogin.Authentication.BankId.Api.Models;
 
 namespace ActiveLogin.Authentication.BankId.AspNetCore.Test
 {
@@ -171,8 +173,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Test
         public async Task AutoLaunch_Sets_Correct_RedirectUri()
         {
 	        // Arrange mocks
-	        var identityNumber = "195008212226";
-	        var autoLaunchOptions = new BankIdLoginOptions(new List<string>(), SwedishPersonalIdentityNumber.Parse(identityNumber), false, true, false);
+	        var autoLaunchOptions = new BankIdLoginOptions(new List<string>(), null, false, true, false);
 	        var mockProtector =  new Mock<IBankIdLoginOptionsProtector>();
 	        mockProtector
 		        .Setup(protector => protector.Unprotect(It.IsAny<string>()))
@@ -214,12 +215,70 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Test
 	        Assert.Equal(HttpStatusCode.OK, transaction.StatusCode);
 
 	        var responseContent = await transaction.Content.ReadAsStringAsync();
-	        var responseObject = JsonConvert.DeserializeAnonymousType(responseContent, new { RedirectUri = "", OrderRef = "", IsAutoLaunch = false });
+            var responseObject = JsonConvert.DeserializeAnonymousType(responseContent, new { RedirectUri = "", OrderRef = "", IsAutoLaunch = false });
 	        Assert.True(responseObject.IsAutoLaunch);
 
 	        var encodedReturnParam = UrlEncoder.Default.Encode(testReturnUrl);
 	        var expectedUrl = $"http://localhost/BankIdAuthentication/Login?returnUrl={encodedReturnParam}&loginOptions={testOptions}";
 	        Assert.Equal(expectedUrl, responseObject.RedirectUri);
+        }
+
+        [Fact]
+        public async Task Cancel_Calls_CancelApi()
+        {
+            // Arrange mocks
+            var autoLaunchOptions = new BankIdLoginOptions(new List<string>(), null, false, true, false);
+            var mockProtector = new Mock<IBankIdLoginOptionsProtector>();
+            mockProtector
+                .Setup(protector => protector.Unprotect(It.IsAny<string>()))
+                .Returns(autoLaunchOptions);
+            var testBankIdApi = new TestBankIdApi(new BankIdSimulatedApiClient());
+
+            var client = CreateServer(
+                    o =>
+                    {
+                        o.AuthenticationBuilder.Services.TryAddTransient<IBankIdLauncher, TestBankIdLauncher>();
+                        o.UseSimulatedEnvironment().AddSameDevice();
+                    },
+                    DefaultAppConfiguration(async context =>
+                    {
+                        await context.ChallengeAsync(BankIdAuthenticationDefaults.SameDeviceAuthenticationScheme);
+                    }),
+                    services =>
+                    {
+                        services.AddTransient(s => mockProtector.Object);
+                        services.AddSingleton<IBankIdApiClient>(s => testBankIdApi);
+                    })
+                .CreateClient();
+
+            // Arrange csrf info
+            var loginResponse = await client.GetAsync("/BankIdAuthentication/Login?returnUrl=%2F&loginOptions=X&orderRef=Y");
+            var loginCookies = loginResponse.Headers.GetValues("set-cookie").ToList();
+            var loginContent = await loginResponse.Content.ReadAsStringAsync();
+            var csrfToken = TokenExtractor.ExtractRequestVerificationTokenFromForm(loginContent);
+
+            // Arrange acting request
+            var testReturnUrl = "/TestReturnUrl";
+            var testOptions = "TestOptions";
+
+            var initializeRequest = new JsonContent(new { returnUrl = testReturnUrl, loginOptions = testOptions });
+            initializeRequest.Headers.Add("Cookie", loginCookies);
+            initializeRequest.Headers.Add("RequestVerificationToken", csrfToken);
+
+            var initializeTransaction = await client.PostAsync("/BankIdAuthentication/Api/Initialize", initializeRequest);
+            var initializeResponseContent = await initializeTransaction.Content.ReadAsStringAsync();
+            var initializeObject = JsonConvert.DeserializeAnonymousType(initializeResponseContent, new { RedirectUri = "", OrderRef = "", IsAutoLaunch = false });
+
+            var cancelRequest = new JsonContent(new { orderRef = initializeObject.OrderRef });
+            cancelRequest.Headers.Add("Cookie", loginCookies);
+            cancelRequest.Headers.Add("RequestVerificationToken", csrfToken);
+
+            // Act
+            var cancelTransaction = await client.PostAsync("/BankIdAuthentication/Api/Cancel", cancelRequest);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, cancelTransaction.StatusCode);
+            Assert.True(testBankIdApi.CancelAsyncIsCalled);
         }
 
         private TestServer CreateServer(
@@ -262,6 +321,39 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Test
                 });
                 app.Run(context => context.Response.WriteAsync(""));
             };
+        }
+
+        private class TestBankIdApi : IBankIdApiClient
+        {
+            private readonly IBankIdApiClient _bankIdApiClient;
+
+            public bool CancelAsyncIsCalled { get; private set; }
+
+            public TestBankIdApi(IBankIdApiClient bankIdApiClient)
+            {
+                _bankIdApiClient = bankIdApiClient;
+            }
+
+            public Task<AuthResponse> AuthAsync(AuthRequest request)
+            {
+                return _bankIdApiClient.AuthAsync(request);
+            }
+
+            public Task<SignResponse> SignAsync(SignRequest request)
+            {
+                return _bankIdApiClient.SignAsync(request);
+            }
+
+            public Task<CollectResponse> CollectAsync(CollectRequest request)
+            {
+                return _bankIdApiClient.CollectAsync(request);
+            }
+
+            public Task<CancelResponse> CancelAsync(CancelRequest request)
+            {
+                CancelAsyncIsCalled = true;
+                return _bankIdApiClient.CancelAsync(request);
+            }
         }
     }
 }

--- a/test/ActiveLogin.Authentication.BankId.AspNetCore.Test/BankId_Authentication_Tests.cs
+++ b/test/ActiveLogin.Authentication.BankId.AspNetCore.Test/BankId_Authentication_Tests.cs
@@ -140,7 +140,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Test
         }
 
         [NoLinuxFact("Issues with layout pages from unit tests on Linux")]
-        public async Task BankIdAuthentication_Login_Returns_Form()
+        public async Task BankIdAuthentication_Login_Returns_Form_And_Status()
         {
             // Arrange
             var client = CreateServer(o =>
@@ -164,6 +164,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Test
             Assert.Equal(HttpStatusCode.OK, transaction.StatusCode);
             var content = await transaction.Content.ReadAsStringAsync();
             Assert.Contains("<form id=\"bankIdLoginForm\">", content);
+            Assert.Contains("<div id=\"bankIdLoginStatus\"", content);
         }
 
         [Fact]


### PR DESCRIPTION
This commit adds a cancel button to the status view. When clicked the button triggers a post request to a new endpoint in the BankIdApiController. The new endpoint then asks the BankID client to cancel the outstanding authentication request.

If the cancellation is successful, control is returned to the GUI where the status information is hidden and the form field and buttons for initiating a BankID authn request are once again visible.

If an error occurs, the status of the error is displayed as in the check status call. Let's open a new feature request to add/redirect the user to something more meaningful: #135 .

Ref ActiveLogin/ActiveLogin.Authentication#119