### PR TITLE
Bug/cancel same device

### DIFF
--- a/docs/getting-started-bankid.md
+++ b/docs/getting-started-bankid.md
@@ -239,6 +239,31 @@ If you want to apply some options for all BankID schemes, you can do so by using
 });
 ```
 
+### Setting the return URL for cancellation
+
+The defaults for cancellation are as follows:
+
+* Same Device Scheme returns to scheme selection
+* Other Device Scheme returns to scheme selection when using QR codes
+* Other Device Scheme returns to PIN input when using PIN input instead of QR codes
+
+It is possible to override the default navigation when cancelling an authentication request. The URL used for navigation is set through the `cancelReturnUrl` item in the `AuthenticationProperties` passed in the authentication challenge.
+
+```
+var props = new AuthenticationProperties
+{
+    RedirectUri = Url.Action(nameof(ExternalLoginCallback)),
+    Items =
+    {
+        { "returnUrl", "~/" },
+        { "cancelReturnUrl", "~/some-custom-cancellation-url" },
+        { "scheme", provider }
+    }
+};
+
+return Challenge(props, provider);
+```
+
 ### BankID Certificate Policies
 
 BankId options allows you to set a list of certificate policies and there is a class available to help you out with this.

--- a/samples/IdentityServer.ServerSample/Controllers/AccountController.cs
+++ b/samples/IdentityServer.ServerSample/Controllers/AccountController.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
+using ActiveLogin.Authentication.BankId.AspNetCore;
 using IdentityServer.ServerSample.Models;
 using IdentityServer4.Models;
 using IdentityServer4.Services;
@@ -50,6 +51,11 @@ namespace IdentityServer.ServerSample.Controllers
                     {"scheme", provider}
                 }
             };
+
+            if (provider.Equals(BankIdAuthenticationDefaults.SameDeviceAuthenticationScheme))
+            {
+                props.Items["cancelReturnUrl"] = returnUrl;
+            }
 
             return Challenge(props, provider);
         }

--- a/samples/IdentityServer.ServerSample/Controllers/AccountController.cs
+++ b/samples/IdentityServer.ServerSample/Controllers/AccountController.cs
@@ -52,11 +52,6 @@ namespace IdentityServer.ServerSample.Controllers
                 }
             };
 
-            if (provider.Equals(BankIdAuthenticationDefaults.SameDeviceAuthenticationScheme))
-            {
-                props.Items["cancelReturnUrl"] = returnUrl;
-            }
-
             return Challenge(props, provider);
         }
 

--- a/samples/IdentityServer.ServerSample/Controllers/AccountController.cs
+++ b/samples/IdentityServer.ServerSample/Controllers/AccountController.cs
@@ -47,10 +47,15 @@ namespace IdentityServer.ServerSample.Controllers
                 RedirectUri = Url.Action(nameof(ExternalLoginCallback)),
                 Items =
                 {
-                    {"returnUrl", returnUrl},
-                    {"scheme", provider}
+                    { "returnUrl", returnUrl },
+                    { "scheme", provider },
                 }
             };
+
+            if (provider.Equals(BankIdAuthenticationDefaults.SameDeviceAuthenticationScheme))
+            {
+                props.Items.Add("cancelReturnUrl", Url.ActionLink("Login", "Account", new { returnUrl }));
+            }
 
             return Challenge(props, provider);
         }

--- a/samples/IdentityServer.ServerSample/Controllers/AccountController.cs
+++ b/samples/IdentityServer.ServerSample/Controllers/AccountController.cs
@@ -49,13 +49,9 @@ namespace IdentityServer.ServerSample.Controllers
                 {
                     { "returnUrl", returnUrl },
                     { "scheme", provider },
+                    { "cancelReturnUrl", Url.ActionLink("Login", "Account", new { returnUrl }) }
                 }
             };
-
-            if (provider.Equals(BankIdAuthenticationDefaults.SameDeviceAuthenticationScheme))
-            {
-                props.Items.Add("cancelReturnUrl", Url.ActionLink("Login", "Account", new { returnUrl }));
-            }
 
             return Challenge(props, provider);
         }

--- a/samples/Standalone.MvcSample/Controllers/AccountController.cs
+++ b/samples/Standalone.MvcSample/Controllers/AccountController.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
+using ActiveLogin.Authentication.BankId.AspNetCore;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -49,6 +50,11 @@ namespace Standalone.MvcSample.Controllers
                     {"scheme", provider}
                 }
             };
+
+            if (provider.Equals(BankIdAuthenticationDefaults.SameDeviceAuthenticationScheme))
+            {
+                props.Items["cancelReturnUrl"] = "~/";
+            }
 
             return Challenge(props, provider);
         }

--- a/samples/Standalone.MvcSample/Controllers/AccountController.cs
+++ b/samples/Standalone.MvcSample/Controllers/AccountController.cs
@@ -51,11 +51,6 @@ namespace Standalone.MvcSample.Controllers
                 }
             };
 
-            if (provider.Equals(BankIdAuthenticationDefaults.SameDeviceAuthenticationScheme))
-            {
-                props.Items["cancelReturnUrl"] = "~/";
-            }
-
             return Challenge(props, provider);
         }
 

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Controllers/BankIdApiController.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Controllers/BankIdApiController.cs
@@ -288,7 +288,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthenticatio
 
             _logger.BankIdAuthCancelled(orderRef.OrderRef);
 
-            return Ok(BankIdLoginApiCancelResponse.Cancelled());
+            return Ok(BankIdLoginApiCancelResponse.Cancelled(request.CancelReturnUrl));
         }
     }
 }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Controllers/BankIdController.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Controllers/BankIdController.cs
@@ -68,6 +68,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthenticatio
             return new BankIdLoginViewModel
             {
                 ReturnUrl = returnUrl,
+                CancelReturnUrl = unprotectedLoginOptions.CancelReturnUrl,
 
                 AutoLogin = unprotectedLoginOptions.IsAutoLogin(),
                 PersonalIdentityNumber = unprotectedLoginOptions.PersonalIdentityNumber?.To12DigitString() ?? string.Empty,

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Models/BankIdLoginApiCancelRequest.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Models/BankIdLoginApiCancelRequest.cs
@@ -12,5 +12,6 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthenticatio
         [Required]
         public string OrderRef { get; set; }
 
+        public string CancelReturnUrl { get; set; }
     }
 }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Models/BankIdLoginApiCancelResponse.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Models/BankIdLoginApiCancelResponse.cs
@@ -2,14 +2,16 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthenticatio
 {
     public class BankIdLoginApiCancelResponse
     {
+        public string CancelReturnUrl { get; set; }
+
         internal BankIdLoginApiCancelResponse()
         {
 
         }
 
-        public static BankIdLoginApiCancelResponse Cancelled()
+        public static BankIdLoginApiCancelResponse Cancelled(string cancelReturnUrl)
         {
-            return new BankIdLoginApiCancelResponse();
+            return new BankIdLoginApiCancelResponse { CancelReturnUrl = cancelReturnUrl };
         }
     }
 }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Models/BankIdLoginViewModel.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Models/BankIdLoginViewModel.cs
@@ -7,10 +7,11 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthenticatio
     {
         internal BankIdLoginViewModel()
         {
-            
+
         }
 
         public string ReturnUrl { get; set; }
+        public string CancelReturnUrl { get; set; }
 
         public bool AutoLogin { get; set; }
         public string PersonalIdentityNumber { get; set; }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Views/BankId/_LoginForm.cshtml
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Views/BankId/_LoginForm.cshtml
@@ -5,6 +5,7 @@
 <form id="bankIdLoginForm">
     <input name="RequestVerificationToken" type="hidden" value="@Model.AntiXsrfRequestToken">
     <input name="ReturnUrl" type="hidden" value="@Model.ReturnUrl" />
+    <input name="CancelReturnUrl" type="hidden" value="@Model.CancelReturnUrl" />
     <input name="LoginOptions" type="hidden" value="@Model.LoginOptions" />
     <input name="AutoLogin" type="hidden" value="@(Model.AutoLogin ? "true" : "false")" />
 
@@ -25,5 +26,4 @@
             </button>
         }
     </fieldset>
-
 </form>

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Views/BankId/_LoginScript.cshtml
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Views/BankId/_LoginScript.cshtml
@@ -163,6 +163,10 @@
         }
 
         function checkStatus(requestVerificationToken, returnUrl, loginOptions, orderRef) {
+            if (loginIsCancelledByUser) {
+                return;
+            }
+
             postJson(options.bankIdStatusApiUrl, requestVerificationToken,
                 {
                     'orderRef': orderRef,

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Views/BankId/_LoginScript.cshtml
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Views/BankId/_LoginScript.cshtml
@@ -72,17 +72,18 @@
         function login() {
             var requestVerificationTokenElement = formElement.querySelector('[name="RequestVerificationToken"]');
             var returnUrlElement = formElement.querySelector('[name="ReturnUrl"]');
+            var cancelReturnUrlElement = formElement.querySelector('[name="CancelReturnUrl"]');
             var loginOptionsElement = formElement.querySelector('[name="LoginOptions"]');
             var personalIdentityNumberElement = formElement.querySelector('[name="PersonalIdentityNumber"]');
             var personalIdentityNumber = !!personalIdentityNumberElement ? personalIdentityNumberElement.value : '';
 
-            initialize(requestVerificationTokenElement.value, returnUrlElement.value, loginOptionsElement.value, personalIdentityNumber, personalIdentityNumberElement);
+            initialize(requestVerificationTokenElement.value, returnUrlElement.value, cancelReturnUrlElement.value, loginOptionsElement.value, personalIdentityNumber, personalIdentityNumberElement);
         }
 
         // BankID
 
         var loginIsCancelledByUser = false;
-        function initialize(requestVerificationToken, returnUrl, loginOptions, personalIdentityNumber, personalIdentityNumberElement) {
+        function initialize(requestVerificationToken, returnUrl, cancelUrl, loginOptions, personalIdentityNumber, personalIdentityNumberElement) {
             loginIsCancelledByUser = false;
             formFieldsetElement.disabled = true;
             show(formSubmitButtonSpinnerElement);
@@ -129,7 +130,7 @@
                         }
 
                         var onCancelButtonClick = function(event) {
-                            cancel(requestVerificationToken, data.orderRef);
+                            cancel(requestVerificationToken, cancelUrl, data.orderRef);
                             event.target.removeEventListener('click', onCancelButtonClick);
                         };
                         cancelButtonElement.addEventListener('click', onCancelButtonClick);
@@ -146,14 +147,19 @@
                 });
         }
 
-        function cancel(requestVerificationToken, orderRef) {
+        function cancel(requestVerificationToken, cancelReturnUrl, orderRef) {
             loginIsCancelledByUser = true;
             postJson(options.bankIdCancelApiUrl, requestVerificationToken, {
-                'orderRef': orderRef
-            }).then(function() {
+                'orderRef': orderRef,
+                'cancelReturnUrl': cancelReturnUrl
+            }).then(function(data) {
                 hide(statusElement);
                 show(formElement);
                 formFieldsetElement.disabled = false;
+
+                if (data.cancelReturnUrl) {
+                    window.location.href = data.cancelReturnUrl;
+                }
             }).catch(function(error) {
                 showStatus(error.message, 'danger', false);
                 hide(startBankIdAppButtonElement);

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Views/BankId/_LoginScript.cshtml
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Views/BankId/_LoginScript.cshtml
@@ -157,7 +157,7 @@
                 show(formElement);
                 formFieldsetElement.disabled = false;
 
-                if (data.cancelReturnUrl) {
+                if (!!data.cancelReturnUrl) {
                     window.location.href = data.cancelReturnUrl;
                 }
             }).catch(function(error) {

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Views/BankId/_LoginScript.cshtml
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Views/BankId/_LoginScript.cshtml
@@ -153,12 +153,12 @@
                 'orderRef': orderRef,
                 'cancelReturnUrl': cancelReturnUrl
             }).then(function(data) {
-                hide(statusElement);
-                show(formElement);
-                formFieldsetElement.disabled = false;
-
                 if (!!data.cancelReturnUrl) {
                     window.location.href = data.cancelReturnUrl;
+                } else {
+                    hide(statusElement);
+                    show(formElement);
+                    formFieldsetElement.disabled = false;
                 }
             }).catch(function(error) {
                 showStatus(error.message, 'danger', false);

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdAuthenticationHandler.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdAuthenticationHandler.cs
@@ -169,7 +169,17 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore
 
         private string GetCancelUrl(AuthenticationProperties properties)
         {
-            return properties.Items.TryGetValue("cancelReturnUrl", out var url) ? url : string.Empty;
+            // Default to root if no return url is set
+            var cancelUrl = properties.Items.TryGetValue("returnUrl", out var url) ? url : "/";
+
+            // If we are using other device authentication and manual PIN entry we do not redirect back to
+            // returnUrl but. Instead we let the GUI decide what to display. Preferably the PIN entry form.
+            if (Scheme.Name.Equals(BankIdAuthenticationDefaults.OtherDeviceAuthenticationScheme) && !Options.BankIdUseQrCode)
+            {
+                cancelUrl = string.Empty;
+            }
+
+            return cancelUrl;
         }
 
         private string GetLoginUrl(BankIdLoginOptions loginOptions)

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdAuthenticationHandler.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdAuthenticationHandler.cs
@@ -143,7 +143,8 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore
                 Options.BankIdAllowChangingPersonalIdentityNumber,
                 Options.BankIdAutoLaunch,
                 Options.BankIdAllowBiometric,
-                Options.BankIdUseQrCode
+                Options.BankIdUseQrCode,
+                GetCancelUrl(properties)
             );
             var loginUrl = GetLoginUrl(loginOptions);
             Response.Redirect(loginUrl);
@@ -164,6 +165,11 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore
             }
 
             return null;
+        }
+
+        private string GetCancelUrl(AuthenticationProperties properties)
+        {
+            return properties.Items.TryGetValue("cancelReturnUrl", out var url) ? url : string.Empty;
         }
 
         private string GetLoginUrl(BankIdLoginOptions loginOptions)

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdAuthenticationHandler.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdAuthenticationHandler.cs
@@ -144,7 +144,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore
                 Options.BankIdAutoLaunch,
                 Options.BankIdAllowBiometric,
                 Options.BankIdUseQrCode,
-                GetCancelUrl(properties)
+                GetCancelReturnUrl(properties)
             );
             var loginUrl = GetLoginUrl(loginOptions);
             Response.Redirect(loginUrl);
@@ -167,19 +167,19 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore
             return null;
         }
 
-        private string GetCancelUrl(AuthenticationProperties properties)
+        private string GetCancelReturnUrl(AuthenticationProperties properties)
         {
             // Default to root if no return url is set
-            var cancelUrl = properties.Items.TryGetValue("returnUrl", out var url) ? url : "/";
+            var cancelReturnUrl = properties.Items.TryGetValue("returnUrl", out var url) ? url : "/";
 
             // If we are using other device authentication and manual PIN entry we do not redirect back to
             // returnUrl but. Instead we let the GUI decide what to display. Preferably the PIN entry form.
             if (Scheme.Name.Equals(BankIdAuthenticationDefaults.OtherDeviceAuthenticationScheme) && !Options.BankIdUseQrCode)
             {
-                cancelUrl = string.Empty;
+                cancelReturnUrl = string.Empty;
             }
 
-            return cancelUrl;
+            return cancelReturnUrl;
         }
 
         private string GetLoginUrl(BankIdLoginOptions loginOptions)

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdAuthenticationHandler.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdAuthenticationHandler.cs
@@ -170,7 +170,9 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore
         private string GetCancelReturnUrl(AuthenticationProperties properties)
         {
             // Default to root if no return url is set
-            var cancelReturnUrl = properties.Items.TryGetValue("returnUrl", out var url) ? url : "/";
+            var cancelReturnUrl = properties.Items["cancelReturnUrl"] ??
+                                  properties.Items["returnUrl"] ??
+                                  "/";
 
             // If we are using other device authentication and manual PIN entry we do not redirect back to
             // returnUrl but. Instead we let the GUI decide what to display. Preferably the PIN entry form.

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdAuthenticationHandler.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdAuthenticationHandler.cs
@@ -169,13 +169,17 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore
 
         private string GetCancelReturnUrl(AuthenticationProperties properties)
         {
+            // If cancel url is set, it overrides any scheme specific redirection
+            if (properties.Items.TryGetValue("cancelReturnUrl", out var cancelUrl))
+            {
+                return cancelUrl;
+            }
+
             // Default to root if no return url is set
-            var cancelReturnUrl = properties.Items["cancelReturnUrl"] ??
-                                  properties.Items["returnUrl"] ??
-                                  "/";
+            var cancelReturnUrl = properties.Items.ContainsKey("returnUrl") ? properties.Items["returnUrl"] : "/";
 
             // If we are using other device authentication and manual PIN entry we do not redirect back to
-            // returnUrl but. Instead we let the GUI decide what to display. Preferably the PIN entry form.
+            // returnUrl. Instead we let the GUI decide what to display. Preferably the PIN entry form.
             if (Scheme.Name.Equals(BankIdAuthenticationDefaults.OtherDeviceAuthenticationScheme) && !Options.BankIdUseQrCode)
             {
                 cancelReturnUrl = string.Empty;

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdAuthenticationHandler.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdAuthenticationHandler.cs
@@ -169,14 +169,15 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore
 
         private string GetCancelReturnUrl(AuthenticationProperties properties)
         {
-            // If cancel url is set, it overrides any scheme specific redirection
-            if (properties.Items.TryGetValue("cancelReturnUrl", out var cancelUrl))
-            {
-                return cancelUrl;
-            }
-
             // Default to root if no return url is set
             var cancelReturnUrl = properties.Items.ContainsKey("returnUrl") ? properties.Items["returnUrl"] : "/";
+
+
+            // If cancel url is set, it overrides the regular return url
+            if (properties.Items.TryGetValue("cancelReturnUrl", out var cancelUrl))
+            {
+                cancelReturnUrl = cancelUrl;
+            }
 
             // If we are using other device authentication and manual PIN entry we do not redirect back to
             // returnUrl. Instead we let the GUI decide what to display. Preferably the PIN entry form.

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Models/BankIdLoginOptions.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Models/BankIdLoginOptions.cs
@@ -33,6 +33,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Models
         public bool AllowBiometric { get; }
 
         public bool UseQrCode { get; set; }
+
         public string CancelReturnUrl { get; }
     }
 }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Models/BankIdLoginOptions.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Models/BankIdLoginOptions.cs
@@ -11,7 +11,8 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Models
             bool allowChangingPersonalIdentityNumber,
             bool autoLaunch,
             bool allowBiometric,
-            bool useQrCode)
+            bool useQrCode,
+            string cancelReturnUrl)
         {
             CertificatePolicies = certificatePolicies;
             PersonalIdentityNumber = personalIdentityNumber;
@@ -19,6 +20,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Models
             AutoLaunch = autoLaunch;
             AllowBiometric = allowBiometric;
             UseQrCode = useQrCode;
+            CancelReturnUrl = cancelReturnUrl;
         }
 
         public List<string> CertificatePolicies { get; }
@@ -31,5 +33,6 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Models
         public bool AllowBiometric { get; }
 
         public bool UseQrCode { get; set; }
+        public string CancelReturnUrl { get; }
     }
 }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Serialization/BankIdLoginOptionsSerializer.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Serialization/BankIdLoginOptionsSerializer.cs
@@ -10,7 +10,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Serialization
 {
     internal class BankIdLoginOptionsSerializer : IDataSerializer<BankIdLoginOptions>
     {
-        private const int FormatVersion = 2;
+        private const int FormatVersion = 3;
         private const char CertificatePoliciesSeparator = ';';
 
         public byte[] Serialize(BankIdLoginOptions model)
@@ -27,6 +27,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Serialization
                     writer.Write(model.AutoLaunch);
                     writer.Write(model.AllowBiometric);
                     writer.Write(model.UseQrCode);
+                    writer.Write(model.CancelReturnUrl ?? string.Empty);
 
                     writer.Flush();
                     return memory.ToArray();
@@ -52,6 +53,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Serialization
                     var autoLaunch = reader.ReadBoolean();
                     var allowBiometric = reader.ReadBoolean();
                     var displayQrCode = reader.ReadBoolean();
+                    var cancelReturnUrl = reader.ReadString();
 
                     return new BankIdLoginOptions(
                         certificatePolicies,
@@ -59,7 +61,8 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Serialization
                         allowChangingPersonalIdentityNumber,
                         autoLaunch,
                         allowBiometric,
-                        displayQrCode
+                        displayQrCode,
+                        cancelReturnUrl
                     );
                 }
             }

--- a/test/ActiveLogin.Authentication.BankId.AspNetCore.Test/BankId_Authentication_Tests.cs
+++ b/test/ActiveLogin.Authentication.BankId.AspNetCore.Test/BankId_Authentication_Tests.cs
@@ -36,8 +36,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Test
             _bankIdLoginOptionsProtector = new Mock<IBankIdLoginOptionsProtector>();
             _bankIdLoginOptionsProtector
                 .Setup(protector => protector.Unprotect(It.IsAny<string>()))
-
-                .Returns(new BankIdLoginOptions(new List<string>(), null, false, false, false, false, String.Empty));
+                .Returns(new BankIdLoginOptions(new List<string>(), null, false, false, false, false, "/"));
         }
 
         [NoLinuxFact("Issues with layout pages from unit tests on Linux")]
@@ -170,6 +169,10 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Test
             Assert.Contains("<form id=\"bankIdLoginForm\">", content);
             Assert.Contains("<div id=\"bankIdLoginStatus\" style=\"display: block;\">", content);
             Assert.Contains("<img src=\"\" alt=\"QR Code for BankID\" class=\"qr-code-image img-thumbnail img-fluid mb-2\" style=\"display: none;\" />", content);
+            Assert.Contains("<input name=\"ReturnUrl\" type=\"hidden\" value=\"/\" />", content);
+            Assert.Contains("<input name=\"CancelReturnUrl\" type=\"hidden\" value=\"/\" />", content);
+            Assert.Contains("<input name=\"LoginOptions\" type=\"hidden\" value=\"X\" />", content);
+            Assert.Contains("<input name=\"AutoLogin\" type=\"hidden\" value=\"true\" />", content);
         }
 
         [Fact]

--- a/test/ActiveLogin.Authentication.BankId.AspNetCore.Test/BankId_Authentication_Tests.cs
+++ b/test/ActiveLogin.Authentication.BankId.AspNetCore.Test/BankId_Authentication_Tests.cs
@@ -36,7 +36,8 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Test
             _bankIdLoginOptionsProtector = new Mock<IBankIdLoginOptionsProtector>();
             _bankIdLoginOptionsProtector
                 .Setup(protector => protector.Unprotect(It.IsAny<string>()))
-                .Returns(new BankIdLoginOptions(new List<string>(), null, false, false, false, false));
+
+                .Returns(new BankIdLoginOptions(new List<string>(), null, false, false, false, false, String.Empty));
         }
 
         [NoLinuxFact("Issues with layout pages from unit tests on Linux")]
@@ -175,7 +176,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Test
         public async Task AutoLaunch_Sets_Correct_RedirectUri()
         {
 	        // Arrange mocks
-	        var autoLaunchOptions = new BankIdLoginOptions(new List<string>(), null, false, true, false, false);
+            var autoLaunchOptions = new BankIdLoginOptions(new List<string>(), null, false, true, false, false, String.Empty);
 	        var mockProtector =  new Mock<IBankIdLoginOptionsProtector>();
 	        mockProtector
 		        .Setup(protector => protector.Unprotect(It.IsAny<string>()))
@@ -229,7 +230,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Test
         public async Task Cancel_Calls_CancelApi()
         {
             // Arrange mocks
-            var autoLaunchOptions = new BankIdLoginOptions(new List<string>(), null, false, true, false, false);
+            var autoLaunchOptions = new BankIdLoginOptions(new List<string>(), null, false, true, false, false, String.Empty);
             var mockProtector = new Mock<IBankIdLoginOptionsProtector>();
             mockProtector
                 .Setup(protector => protector.Unprotect(It.IsAny<string>()))


### PR DESCRIPTION
Use cancel return url for samedevice auth

This commit adds a new property 'cancelReturnUrl' that is
used by the samedevice scheme to redirect the user back
to the initial page if they cancel an ongoing auth
process.

Currently it limits the cancelUrl to the samedevice
only but it is possible to allow the cancel url to be
set for the otherdevice scheme as well without too
much hassle.

Ref ActiveLogin/ActiveLogin.Authentication#143

Note. This will most probably conflict with #138 . We will have to rebase once the first is completed.