### PR TITLE
Support forwarded and cdn headers

### DIFF
--- a/docs/getting-started-bankid.md
+++ b/docs/getting-started-bankid.md
@@ -226,6 +226,9 @@ BankId options allows you to set and override some options such as these.
     // Turn off 
     code and use personal identity number instead
     options.BankIdUseQrCode = false;
+
+    // Disable forwarded headers
+    options.AllowForwardedHeaders = false;
 });
 ```
 

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdAuthenticationBuilderSchemeExtensions.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdAuthenticationBuilderSchemeExtensions.cs
@@ -46,6 +46,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore
                     options.CallbackPath = BankIdAuthenticationDefaults.SameDeviceCallbackPath;
                     options.BankIdAutoLaunch = true;
                     options.BankIdAllowChangingPersonalIdentityNumber = false;
+                    options.BankIdAllowForwardedHeaders = true;
                 });
 
 
@@ -65,6 +66,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore
                 options.BankIdAutoLaunch = false;
                 options.BankIdAllowChangingPersonalIdentityNumber = true;
                 options.BankIdUseQrCode = true;
+                options.BankIdAllowForwardedHeaders = true;
             });
     }
 }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdAuthenticationHandler.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdAuthenticationHandler.cs
@@ -143,7 +143,8 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore
                 Options.BankIdAllowChangingPersonalIdentityNumber,
                 Options.BankIdAutoLaunch,
                 Options.BankIdAllowBiometric,
-                Options.BankIdUseQrCode
+                Options.BankIdUseQrCode,
+                Options.BankIdAllowForwardedHeaders
             );
             var loginUrl = GetLoginUrl(loginOptions);
             Response.Redirect(loginUrl);

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdAuthenticationOptions.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdAuthenticationOptions.cs
@@ -73,5 +73,19 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore
             get => _stateCookieBuilder;
             set => _stateCookieBuilder = value ?? throw new ArgumentNullException(nameof(value));
         }
+
+        /// <summary>
+        /// When set to true it checks the forwarded for headers to find the users remote ip address.
+        /// </summary>
+        /// <remarks>
+        /// The priority is as follows. First header sets the value.
+        ///
+        ///    1. CF-Connecting-IP
+        ///    2. X-Original-Forwarded-For
+        ///    3. X-Forwarded-For
+        ///
+        /// If no header exists the ip address will be resolved from the HttpContext.Connection.RemoteIpAddress
+        /// </remarks>
+        public bool BankIdAllowForwardedHeaders { get; set; } = true;
     }
 }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Models/BankIdLoginOptions.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Models/BankIdLoginOptions.cs
@@ -11,7 +11,8 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Models
             bool allowChangingPersonalIdentityNumber,
             bool autoLaunch,
             bool allowBiometric,
-            bool useQrCode)
+            bool useQrCode,
+            bool allowForwardedHeaders)
         {
             CertificatePolicies = certificatePolicies;
             PersonalIdentityNumber = personalIdentityNumber;
@@ -19,6 +20,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Models
             AutoLaunch = autoLaunch;
             AllowBiometric = allowBiometric;
             UseQrCode = useQrCode;
+            AllowForwardedHeaders = allowForwardedHeaders;
         }
 
         public List<string> CertificatePolicies { get; }
@@ -31,5 +33,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Models
         public bool AllowBiometric { get; }
 
         public bool UseQrCode { get; set; }
+
+        public bool AllowForwardedHeaders { get; }
     }
 }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Serialization/BankIdLoginOptionsSerializer.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Serialization/BankIdLoginOptionsSerializer.cs
@@ -10,7 +10,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Serialization
 {
     internal class BankIdLoginOptionsSerializer : IDataSerializer<BankIdLoginOptions>
     {
-        private const int FormatVersion = 2;
+        private const int FormatVersion = 4;
         private const char CertificatePoliciesSeparator = ';';
 
         public byte[] Serialize(BankIdLoginOptions model)

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Serialization/BankIdLoginOptionsSerializer.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Serialization/BankIdLoginOptionsSerializer.cs
@@ -27,6 +27,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Serialization
                     writer.Write(model.AutoLaunch);
                     writer.Write(model.AllowBiometric);
                     writer.Write(model.UseQrCode);
+                    writer.Write(model.AllowForwardedHeaders);
 
                     writer.Flush();
                     return memory.ToArray();
@@ -52,6 +53,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Serialization
                     var autoLaunch = reader.ReadBoolean();
                     var allowBiometric = reader.ReadBoolean();
                     var displayQrCode = reader.ReadBoolean();
+                    var allowForwardedHeaders = reader.ReadBoolean();
 
                     return new BankIdLoginOptions(
                         certificatePolicies,
@@ -59,7 +61,8 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Serialization
                         allowChangingPersonalIdentityNumber,
                         autoLaunch,
                         allowBiometric,
-                        displayQrCode
+                        displayQrCode,
+                        allowForwardedHeaders
                     );
                 }
             }


### PR DESCRIPTION
This commit adds support for using the forwarded headers
as the users remote ip addess. This is useful when the
application is running behind a reverse proxy or in a cdn.

Ref ActiveLogin/ActiveLogin.Authentication#152