### PR TITLE
Add retries for StartFailed hints

### DIFF
--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Controllers/BankIdApiController.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Controllers/BankIdApiController.cs
@@ -208,7 +208,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthenticatio
         private ActionResult CollectFailure(CollectResponse collectResponse, string statusMessage)
         {
             _logger.BankIdCollectFailure(collectResponse.OrderRef, collectResponse.GetCollectHintCode());
-            return BadRequest(new BankIdLoginApiErrorResponse(statusMessage));
+            return BadRequest(new BankIdLoginApiErrorResponse(statusMessage, collectResponse.GetCollectHintCode()));
         }
 
         private async Task<ActionResult> CollectComplete(BankIdLoginApiStatusRequest request, CollectResponse collectResponse)

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Controllers/BankIdApiController.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Controllers/BankIdApiController.cs
@@ -208,7 +208,8 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthenticatio
         private ActionResult CollectFailure(CollectResponse collectResponse, string statusMessage)
         {
             _logger.BankIdCollectFailure(collectResponse.OrderRef, collectResponse.GetCollectHintCode());
-            return BadRequest(new BankIdLoginApiErrorResponse(statusMessage, collectResponse.GetCollectHintCode()));
+            var retry = CollectHintCode.StartFailed.Equals(collectResponse.GetCollectHintCode());
+            return BadRequest(new BankIdLoginApiErrorResponse(statusMessage, retry));
         }
 
         private async Task<ActionResult> CollectComplete(BankIdLoginApiStatusRequest request, CollectResponse collectResponse)

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Models/BankIdLoginApiErrorResponse.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Models/BankIdLoginApiErrorResponse.cs
@@ -12,11 +12,11 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthenticatio
         public BankIdLoginApiErrorResponse(string errorMessage, CollectHintCode hintCode)
         {
             ErrorMessage = errorMessage;
-            HintCode = hintCode.ToString();
+            Retry = CollectHintCode.StartFailed.Equals(hintCode);
         }
 
         public string ErrorMessage { get; }
 
-        public string HintCode { get; }
+        public bool Retry { get; }
     }
 }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Models/BankIdLoginApiErrorResponse.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Models/BankIdLoginApiErrorResponse.cs
@@ -9,14 +9,14 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthenticatio
             ErrorMessage = errorMessage;
         }
 
-        public BankIdLoginApiErrorResponse(string errorMessage, bool retry)
+        public BankIdLoginApiErrorResponse(string errorMessage, bool retryLogin)
         {
             ErrorMessage = errorMessage;
-            Retry = retry;
+            RetryLogin = retryLogin;
         }
 
         public string ErrorMessage { get; }
 
-        public bool Retry { get; }
+        public bool RetryLogin { get; }
     }
 }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Models/BankIdLoginApiErrorResponse.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Models/BankIdLoginApiErrorResponse.cs
@@ -1,6 +1,4 @@
-﻿using ActiveLogin.Authentication.BankId.Api.Models;
-
-namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthentication.Models
+﻿namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthentication.Models
 {
     public class BankIdLoginApiErrorResponse
     {
@@ -9,14 +7,6 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthenticatio
             ErrorMessage = errorMessage;
         }
 
-        public BankIdLoginApiErrorResponse(string errorMessage, bool retryLogin)
-        {
-            ErrorMessage = errorMessage;
-            RetryLogin = retryLogin;
-        }
-
         public string ErrorMessage { get; }
-
-        public bool RetryLogin { get; }
     }
 }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Models/BankIdLoginApiErrorResponse.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Models/BankIdLoginApiErrorResponse.cs
@@ -9,10 +9,10 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthenticatio
             ErrorMessage = errorMessage;
         }
 
-        public BankIdLoginApiErrorResponse(string errorMessage, CollectHintCode hintCode)
+        public BankIdLoginApiErrorResponse(string errorMessage, bool retry)
         {
             ErrorMessage = errorMessage;
-            Retry = CollectHintCode.StartFailed.Equals(hintCode);
+            Retry = retry;
         }
 
         public string ErrorMessage { get; }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Models/BankIdLoginApiErrorResponse.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Models/BankIdLoginApiErrorResponse.cs
@@ -1,4 +1,6 @@
-﻿namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthentication.Models
+﻿using ActiveLogin.Authentication.BankId.Api.Models;
+
+namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthentication.Models
 {
     public class BankIdLoginApiErrorResponse
     {
@@ -7,6 +9,14 @@
             ErrorMessage = errorMessage;
         }
 
+        public BankIdLoginApiErrorResponse(string errorMessage, CollectHintCode hintCode)
+        {
+            ErrorMessage = errorMessage;
+            HintCode = hintCode.ToString();
+        }
+
         public string ErrorMessage { get; }
+
+        public string HintCode { get; }
     }
 }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Models/BankIdLoginApiStatusRequest.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Models/BankIdLoginApiStatusRequest.cs
@@ -6,12 +6,13 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthenticatio
     {
         internal BankIdLoginApiStatusRequest()
         {
-            
+
         }
 
         [Required]
         public string OrderRef { get; set; }
         public string ReturnUrl { get; set; }
         public string LoginOptions { get; set; }
+        public int AutoStartAttempts { get; set; }
     }
 }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Models/BankIdLoginApiStatusResponse.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Models/BankIdLoginApiStatusResponse.cs
@@ -2,6 +2,12 @@
 {
     public class BankIdLoginApiStatusResponse
     {
+        internal BankIdLoginApiStatusResponse(string statusMessage, bool retryLogin)
+        {
+            StatusMessage = statusMessage;
+            RetryLogin = retryLogin;
+        }
+
         internal BankIdLoginApiStatusResponse(bool isFinished, string statusMessage, string redirectUri)
         {
             IsFinished = isFinished;
@@ -9,10 +15,10 @@
             RedirectUri = redirectUri;
         }
 
-
         public bool IsFinished { get; }
         public string StatusMessage { get; }
         public string RedirectUri { get; }
+        public bool RetryLogin { get; }
 
 
         public static BankIdLoginApiStatusResponse Finished(string redirectUri)
@@ -23,6 +29,11 @@
         public static BankIdLoginApiStatusResponse Pending(string statusMessage)
         {
             return new BankIdLoginApiStatusResponse(false, statusMessage, null);
+        }
+
+        public static BankIdLoginApiStatusResponse Retry(string statusMessage)
+        {
+            return new BankIdLoginApiStatusResponse(statusMessage, true);
         }
     }
 }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Views/BankId/_LoginScript.cshtml
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Views/BankId/_LoginScript.cshtml
@@ -221,7 +221,7 @@
                     throw Error(options.unknownErrorMessage);
                 })
                 .then(function (data) {
-                    if (data.hintCode === 'StartFailed') {
+                    if (data.retry) {
                         if (autoStartAttempts++ < 5) {
                             login();
                             return;

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Views/BankId/_LoginScript.cshtml
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Views/BankId/_LoginScript.cshtml
@@ -82,6 +82,7 @@
 
         // BankID
 
+        var autoStartAttempts = 0;
         var loginIsCancelledByUser = false;
         function initialize(requestVerificationToken, returnUrl, cancelUrl, loginOptions, personalIdentityNumber, personalIdentityNumberElement) {
             loginIsCancelledByUser = false;
@@ -220,7 +221,14 @@
                     throw Error(options.unknownErrorMessage);
                 })
                 .then(function (data) {
-                    if (!!data.errorMessage) {
+                    if (data.hintCode === 'StartFailed') {
+                        if (autoStartAttempts++ < 5) {
+                            login();
+                            return;
+                        }
+                        autoStartAttempts = 0;
+                        return;
+                    } else if (!!data.errorMessage) {
                         throw Error(data.errorMessage);
                     }
                     return data;

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Views/BankId/_LoginScript.cshtml
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Views/BankId/_LoginScript.cshtml
@@ -178,12 +178,17 @@
                 {
                     'orderRef': orderRef,
                     'returnUrl': returnUrl,
-                    'loginOptions': loginOptions
+                    'loginOptions': loginOptions,
+                    'autoStartAttempts': autoStartAttempts
                 })
                 .then(function (data) {
-                    if (data.isFinished) {
+                    if (data.retryLogin) {
+                        autoStartAttempts++;
+                        login();
+                    } else if (data.isFinished) {
                         window.location.href = data.redirectUri;
                     } else if (!loginIsCancelledByUser) {
+                        autoStartAttempts = 0;
                         showStatus(data.statusMessage, 'white', true);
                         setTimeout(function () {
                             checkStatus(requestVerificationToken, returnUrl, loginOptions, orderRef);
@@ -221,14 +226,7 @@
                     throw Error(options.unknownErrorMessage);
                 })
                 .then(function (data) {
-                    if (data.retry) {
-                        if (autoStartAttempts++ < 5) {
-                            login();
-                            return;
-                        }
-                        autoStartAttempts = 0;
-                        return;
-                    } else if (!!data.errorMessage) {
+                    if (!!data.errorMessage) {
                         throw Error(data.errorMessage);
                     }
                     return data;


### PR DESCRIPTION
This commit adds a retry mechanism for error results with
hint StartFailed. It will retry 5 times before giving up.

Lets see where we can take this naive approach.