### PR TITLE
Provide validated cancellation URL for all BankID cancellations

### DIFF
--- a/src/ActiveLogin.Authentication.BankId.Api/Models/ErrorCode.cs
+++ b/src/ActiveLogin.Authentication.BankId.Api/Models/ErrorCode.cs
@@ -18,9 +18,10 @@
 
         /// <summary>
         /// Invalid parameter. Invalid use of method.
-        /// * Using an orderRef that previously resulted in completed. The order cannot be collected twice. 
+        /// * Using an orderRef that previously resulted in completed. The order cannot be collected twice.
         /// * Using an orderRef that previously resulted in failed. The order cannot be collected twice.
         /// * Using an orderRef that is too old. completed orders can only be collected up to 3 minutes and failed orders up to 5 minutes.
+        /// * Cancelling an orderRef that is already cancelled. The order cannot be cancelled twice.
         ///
         /// RP must not try the same request again.
         /// This is an internal error within RP's system and must not be communicated to the user as a BankID error.

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Controllers/BankIdApiController.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Controllers/BankIdApiController.cs
@@ -337,9 +337,19 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthenticatio
 
             var orderRef = _orderRefProtector.Unprotect(request.OrderRef);
 
-            await _bankIdApiClient.CancelAsync(orderRef.OrderRef);
-
-            _logger.BankIdAuthCancelled(orderRef.OrderRef);
+            try
+            {
+                await _bankIdApiClient.CancelAsync(orderRef.OrderRef);
+                _logger.BankIdAuthCancelled(orderRef.OrderRef);
+            }
+            catch (Exception exception)
+            {
+                // When we get exception in a cancellation request, chances
+                // are that the orderRef has already been cancelled or we have
+                // a network issue. We still want to provide the GUI with the
+                // validated cancellation URL though.
+                _logger.BankIdAuthCancellationFailed(orderRef.OrderRef, exception.Message);
+            }
 
             return Ok(BankIdLoginApiCancelResponse.Cancelled(request.CancelReturnUrl));
         }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdLoggingEvents.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdLoggingEvents.cs
@@ -11,6 +11,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore
         public static readonly EventId BankIdAuthSuccess = new EventId(2_1_1, nameof(BankIdAuthSuccess));
         public static readonly EventId BankIdAuthHardFailure = new EventId(2_1_2, nameof(BankIdAuthHardFailure));
         public static readonly EventId BankIdAuthCancel = new EventId(2_1_3, nameof(BankIdAuthCancel));
+        public static readonly EventId BankIdAuthCancellationFailed = new EventId(2_1_4, nameof(BankIdAuthCancellationFailed));
 
         // BankId API - Collect
         public static readonly EventId BankIdCollectSoftFailure = new EventId(2_2_2, nameof(BankIdCollectSoftFailure));

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/LoggerExtensions.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/LoggerExtensions.cs
@@ -36,6 +36,11 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore
             logger.LogInformation(BankIdLoggingEvents.BankIdAuthCancel, "BankID auth was cancelled with the OrderRef '{OrderRef}'", orderRef);
         }
 
+        public static void BankIdAuthCancellationFailed(this ILogger logger, string orderRef, string message)
+        {
+            logger.LogInformation(BankIdLoggingEvents.BankIdAuthCancellationFailed, "BankID auth cancellation for '{OrderRef}' failed with the message '{Message}'", orderRef, message);
+        }
+
         // BankID API - Collect
 
         public static void BankIdCollectFailure(this ILogger logger, string orderRef, BankIdApiException bankIdApiException)


### PR DESCRIPTION
This commit will swallow any request error between the API and the
BankID service when the user tries to cancel. When a user cancels,
they only have one way back to restart the authentication process
and that is through the cancellation button.

We still keep the validation for order reference and cancel url
though since we want to protect against bad requests coming in
and potential redirection attacks.

This PR fixes #184 

High level overview of this PR:

- [x] Allows the cancellation communication with BankID to fail
- [x] Still validates the order reference and cancellation url
- [x] Logs the cancellation fail for debugging purposes