### PR TITLE
Make response objects for API public

### DIFF
--- a/src/ActiveLogin.Authentication.BankId.Api/Models/AuthResponse.cs
+++ b/src/ActiveLogin.Authentication.BankId.Api/Models/AuthResponse.cs
@@ -1,4 +1,4 @@
-﻿using System.Runtime.Serialization;
+using System.Runtime.Serialization;
 
 namespace ActiveLogin.Authentication.BankId.Api.Models
 {
@@ -8,7 +8,7 @@ namespace ActiveLogin.Authentication.BankId.Api.Models
     [DataContract]
     public class AuthResponse
     {
-        internal AuthResponse(string orderRef, string autoStartToken)
+        public AuthResponse(string orderRef, string autoStartToken)
         {
             OrderRef = orderRef;
             AutoStartToken = autoStartToken;

--- a/src/ActiveLogin.Authentication.BankId.Api/Models/CancelResponse.cs
+++ b/src/ActiveLogin.Authentication.BankId.Api/Models/CancelResponse.cs
@@ -1,4 +1,4 @@
-﻿using System.Runtime.Serialization;
+using System.Runtime.Serialization;
 
 namespace ActiveLogin.Authentication.BankId.Api.Models
 {
@@ -8,7 +8,7 @@ namespace ActiveLogin.Authentication.BankId.Api.Models
     [DataContract]
     public class CancelResponse
     {
-        internal CancelResponse()
+        public CancelResponse()
         {
 
         }

--- a/src/ActiveLogin.Authentication.BankId.Api/Models/CollectResponse.cs
+++ b/src/ActiveLogin.Authentication.BankId.Api/Models/CollectResponse.cs
@@ -1,4 +1,4 @@
-﻿using System.Runtime.Serialization;
+using System.Runtime.Serialization;
 
 namespace ActiveLogin.Authentication.BankId.Api.Models
 {
@@ -8,12 +8,12 @@ namespace ActiveLogin.Authentication.BankId.Api.Models
     [DataContract]
     public class CollectResponse
     {
-        internal CollectResponse(string orderRef, string status, string hintCode)
+        public CollectResponse(string orderRef, string status, string hintCode)
         : this(orderRef, status, hintCode, null)
         {
         }
 
-        internal CollectResponse(string orderRef, string status, string hintCode, CompletionData? completionData)
+        public CollectResponse(string orderRef, string status, string hintCode, CompletionData? completionData)
         {
             OrderRef = orderRef;
             Status = status;

--- a/src/ActiveLogin.Authentication.BankId.Api/Models/CompletionData.cs
+++ b/src/ActiveLogin.Authentication.BankId.Api/Models/CompletionData.cs
@@ -1,11 +1,11 @@
-﻿using System.Runtime.Serialization;
+using System.Runtime.Serialization;
 
 namespace ActiveLogin.Authentication.BankId.Api.Models
 {
     [DataContract]
     public class CompletionData
     {
-        internal CompletionData(User user, Device device, Cert cert, string signature, string ocspResponse)
+        public CompletionData(User user, Device device, Cert cert, string signature, string ocspResponse)
         {
             User = user;
             Device = device;

--- a/src/ActiveLogin.Authentication.BankId.Api/Models/Device.cs
+++ b/src/ActiveLogin.Authentication.BankId.Api/Models/Device.cs
@@ -1,4 +1,4 @@
-﻿using System.Runtime.Serialization;
+using System.Runtime.Serialization;
 
 namespace ActiveLogin.Authentication.BankId.Api.Models
 {
@@ -8,7 +8,7 @@ namespace ActiveLogin.Authentication.BankId.Api.Models
     [DataContract]
     public class Device
     {
-        internal Device(string ipAddress)
+        public Device(string ipAddress)
         {
             IpAddress = ipAddress;
         }

--- a/src/ActiveLogin.Authentication.BankId.Api/Models/SignResponse.cs
+++ b/src/ActiveLogin.Authentication.BankId.Api/Models/SignResponse.cs
@@ -1,4 +1,4 @@
-﻿using System.Runtime.Serialization;
+using System.Runtime.Serialization;
 
 namespace ActiveLogin.Authentication.BankId.Api.Models
 {
@@ -8,7 +8,7 @@ namespace ActiveLogin.Authentication.BankId.Api.Models
     [DataContract]
     public class SignResponse
     {
-        internal SignResponse(string orderRef, string autoStartToken)
+        public SignResponse(string orderRef, string autoStartToken)
         {
             OrderRef = orderRef;
             AutoStartToken = autoStartToken;

--- a/src/ActiveLogin.Authentication.BankId.Api/Models/User.cs
+++ b/src/ActiveLogin.Authentication.BankId.Api/Models/User.cs
@@ -1,4 +1,4 @@
-﻿using System.Runtime.Serialization;
+using System.Runtime.Serialization;
 
 namespace ActiveLogin.Authentication.BankId.Api.Models
 {
@@ -8,7 +8,7 @@ namespace ActiveLogin.Authentication.BankId.Api.Models
     [DataContract]
     public class User
     {
-        internal User(string personalIdentityNumber, string name, string givenName, string surname)
+        public User(string personalIdentityNumber, string name, string givenName, string surname)
         {
             PersonalIdentityNumber = personalIdentityNumber;
             Name = name;

--- a/src/ActiveLogin.Authentication.GrandId.Api/Models/BankIdFederatedLoginResponse.cs
+++ b/src/ActiveLogin.Authentication.GrandId.Api/Models/BankIdFederatedLoginResponse.cs
@@ -1,4 +1,4 @@
-﻿namespace ActiveLogin.Authentication.GrandId.Api.Models
+namespace ActiveLogin.Authentication.GrandId.Api.Models
 {
     public class BankIdFederatedLoginResponse : FederatedLoginResponseBase
     {
@@ -7,7 +7,7 @@
         {
         }
 
-        internal BankIdFederatedLoginResponse(string sessionId, string redirectUrl)
+        public BankIdFederatedLoginResponse(string sessionId, string redirectUrl)
             : base(sessionId, redirectUrl)
         {
         }

--- a/src/ActiveLogin.Authentication.GrandId.Api/Models/BankIdGetSessionResponse.cs
+++ b/src/ActiveLogin.Authentication.GrandId.Api/Models/BankIdGetSessionResponse.cs
@@ -1,4 +1,4 @@
-﻿namespace ActiveLogin.Authentication.GrandId.Api.Models
+namespace ActiveLogin.Authentication.GrandId.Api.Models
 {
     public class BankIdGetSessionResponse : GetSessionResponseBase
     {
@@ -8,7 +8,7 @@
             UserAttributes = fullResponse.UserAttributes;
         }
 
-        internal BankIdGetSessionResponse(string? sessionId, string? username, BankIdGetSessionUserAttributes userAttributes)
+        public BankIdGetSessionResponse(string? sessionId, string? username, BankIdGetSessionUserAttributes userAttributes)
             : base(sessionId, username)
         {
             UserAttributes = userAttributes;

--- a/src/ActiveLogin.Authentication.GrandId.Api/Models/BankIdGetSessionUserAttributes.cs
+++ b/src/ActiveLogin.Authentication.GrandId.Api/Models/BankIdGetSessionUserAttributes.cs
@@ -1,11 +1,11 @@
-﻿using System.Runtime.Serialization;
+using System.Runtime.Serialization;
 
 namespace ActiveLogin.Authentication.GrandId.Api.Models
 {
     [DataContract]
     public class BankIdGetSessionUserAttributes
     {
-        internal BankIdGetSessionUserAttributes(string signature, string givenName, string surname, string name, string personalIdentityNumber, string notBefore, string notAfter, string ipAddress)
+        public BankIdGetSessionUserAttributes(string signature, string givenName, string surname, string name, string personalIdentityNumber, string notBefore, string notAfter, string ipAddress)
         {
             Signature = signature;
             GivenName = givenName;

--- a/src/ActiveLogin.Authentication.GrandId.Api/Models/LogoutResponse.cs
+++ b/src/ActiveLogin.Authentication.GrandId.Api/Models/LogoutResponse.cs
@@ -1,4 +1,4 @@
-﻿namespace ActiveLogin.Authentication.GrandId.Api.Models
+namespace ActiveLogin.Authentication.GrandId.Api.Models
 {
     public class LogoutResponse
     {
@@ -7,7 +7,7 @@
             SessionDeleted = fullResponse.SessionDeleted?.Equals("1") ?? false;
         }
 
-        internal LogoutResponse(bool sessionDeleted)
+        public LogoutResponse(bool sessionDeleted)
         {
             SessionDeleted = sessionDeleted;
         }


### PR DESCRIPTION
This PR fixes #191.

High level overview of this PR:

- [x] Makes Response object for API public so you can implement your own I*Api