### PR TITLE
Add readme files to the packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Slack](https://img.shields.io/badge/slack-@ActiveLogin-blue.svg?logo=slack)](https://join.slack.com/t/activelogin/shared_invite/enQtODQ0ODYyMTgxMjg0LWJhODhiZmFmODYyMWMzZWEwMjdmYWU2NGRhZmQ0MTg0MzIwNzA2OTM3NTJjOTk2MmE1MzIwMzkzYjllMjAyNzg)
 [![Twitter Follow](https://img.shields.io/badge/Twitter-@ActiveLoginSE-blue.svg?logo=twitter)](https://twitter.com/ActiveLoginSE)
 
-ActiveLogin.Authentication enables an application to support Swedish BankID (svenskt BankID) authentication in .NET. Built on NET Standard and packaged as NuGet-packages they are easy to install and use on multiple platforms. Used with Identity Server it can be configured as a provider for Azure AD B2C. Totally free to use! [Commercial support and traning](#support--training) is available if you need assistance or a quick start. 
+ActiveLogin.Authentication enables an application to support Swedish BankID (svenskt BankID) authentication in .NET. Built on NET Standard and packaged as NuGet-packages they are easy to install and use on multiple platforms. Used with Identity Server it can be configured as a provider for Azure AD B2C. Free to use, [commercial support and traning](#support--training) is available if you need assistance or a quick start. 
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ ActiveLogin.Authentication enables an application to support Swedish BankID (sve
 - :earth_americas: Multi language support with English and Swedish out of the box
 - :wrench: Customizable UI
 - :white_square_button: BankID QR code support
-- :diamond_shape_with_a_dot_inside: Can be used as a [Custom Identity Proivder for Azure AD B2C](#how-do-i-use-active-login-to-get-support-for-bankid-or-grandid-in-azure-ad-active-directory-b2c)
+- :diamond_shape_with_a_dot_inside: Can be used as a [Custom Identity Provider for Azure AD B2C](#how-do-i-use-active-login-to-get-support-for-bankid-or-grandid-in-azure-ad-active-directory-b2c)
 
 ## Screenshots
 
@@ -197,8 +197,8 @@ services
     {
         builder
             .UseProductionEnvironment(config => {
-	        config.ApiKey = Configuration.GetValue<string>("ActiveLogin:GrandId:ApiKey");
-	        config.BankIdServiceKey = Configuration.GetValue<string>("ActiveLogin:GrandId:BankIdServiceKey");
+                config.ApiKey = Configuration.GetValue<string>("ActiveLogin:GrandId:ApiKey");
+                config.BankIdServiceKey = Configuration.GetValue<string>("ActiveLogin:GrandId:BankIdServiceKey");
             })
             .AddBankIdSameDevice()
             .AddBankIdOtherDevice();
@@ -320,7 +320,7 @@ public IActionResult ExternalLogin(string provider, string returnUrl, string per
 
 ### Do I need to use your ASP.NET Core Auth provider, or can just use the API?
 
-We have seperated the API-wrappers for both BankID and GrandID into two separate packages so that you can use them in other scenarios we have not covered. The look like this and are both well documented using XML-comments.
+We have seperated the API-wrappers for both BankID and GrandID into two separate packages so that you can use them in other scenarios we have not covered. They look like this and are both well documented using XML-comments.
 
 The constructor for these ApiClients takes an `HttpClient` and you need to configure that `HttpClient` with a `BaseAddress`, `Tls12`, client certificates etc. depending on your needs.
 

--- a/src/ActiveLogin.Authentication.BankId.Api/ActiveLogin.Authentication.BankId.Api.csproj
+++ b/src/ActiveLogin.Authentication.BankId.Api/ActiveLogin.Authentication.BankId.Api.csproj
@@ -28,7 +28,8 @@
         <PackageProjectUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication</PackageProjectUrl>
         <PackageIcon>icon.png</PackageIcon>
         <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
-        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <PackageReadmeFile>readme.md</PackageReadmeFile>
+        <NuspecProperties>readme=readme.md</NuspecProperties>
 
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication.git</RepositoryUrl>

--- a/src/ActiveLogin.Authentication.BankId.Api/ActiveLogin.Authentication.BankId.Api.csproj
+++ b/src/ActiveLogin.Authentication.BankId.Api/ActiveLogin.Authentication.BankId.Api.csproj
@@ -1,57 +1,59 @@
-<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <Nullable>enable</Nullable>
-    <NeutralLanguage>en</NeutralLanguage>
-    <NoWarn>1701;1702;1591;CS7035</NoWarn>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+﻿<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <LangVersion>latest</LangVersion>
+        <Nullable>enable</Nullable>
+        <NeutralLanguage>en</NeutralLanguage>
+        <NoWarn>1701;1702;1591;CS7035</NoWarn>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
-    <AssemblyName>ActiveLogin.Authentication.BankId.Api</AssemblyName>
-    <PackageId>ActiveLogin.Authentication.BankId.Api</PackageId>
+        <AssemblyName>ActiveLogin.Authentication.BankId.Api</AssemblyName>
+        <PackageId>ActiveLogin.Authentication.BankId.Api</PackageId>
 
-    <VersionPrefix>3.0.0</VersionPrefix>
-    <VersionSuffix>beta-2</VersionSuffix>
-    <AssemblyVersion>3.0.0.0</AssemblyVersion>
-    <FileVersion Condition="'$(BUILD_BUILDNUMBER)' == ''">$(VersionPrefix).0</FileVersion>
-    <FileVersion Condition="'$(BUILD_BUILDNUMBER)' != ''">$(VersionPrefix).$(BUILD_BUILDNUMBER)</FileVersion>
+        <VersionPrefix>3.0.0</VersionPrefix>
+        <VersionSuffix>beta-2</VersionSuffix>
+        <AssemblyVersion>3.0.0.0</AssemblyVersion>
+        <FileVersion Condition="'$(BUILD_BUILDNUMBER)' == ''">$(VersionPrefix).0</FileVersion>
+        <FileVersion Condition="'$(BUILD_BUILDNUMBER)' != ''">$(VersionPrefix).$(BUILD_BUILDNUMBER)</FileVersion>
 
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>StrongNameKey.snk</AssemblyOriginatorKeyFile>
+        <SignAssembly>true</SignAssembly>
+        <AssemblyOriginatorKeyFile>StrongNameKey.snk</AssemblyOriginatorKeyFile>
 
-    <Description>API client that enables an application to call Swedish BankID's (svenskt BankIDs) REST API in .NET.</Description>
-    <PackageTags>bankid;swedish;sweden;apiclient;netstandard</PackageTags>
+        <Description>API client that enables an application to call Swedish BankID's (svenskt BankIDs) REST API in .NET.</Description>
+        <PackageTags>bankid;swedish;sweden;apiclient;netstandard</PackageTags>
 
-    <Authors>Active Solution;Peter Örneholm;Nikolay Krondev;Elin Ohlsson;Robert Folkesson;Jakob Ehn</Authors>
-    <Copyright>Copyright © ActiveLogin</Copyright>
+        <Authors>Active Solution;Peter Örneholm;Nikolay Krondev;Elin Ohlsson;Robert Folkesson;Jakob Ehn</Authors>
+        <Copyright>Copyright © ActiveLogin</Copyright>
 
-    <PackageProjectUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication</PackageProjectUrl>
-    <PackageIcon>icon.png</PackageIcon>
-    <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
+        <PackageProjectUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication</PackageProjectUrl>
+        <PackageIcon>icon.png</PackageIcon>
+        <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
 
-    <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication.git</RepositoryUrl>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <RepositoryUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication.git</RepositoryUrl>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
 
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-  </PropertyGroup>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <EmbedUntrackedSources>true</EmbedUntrackedSources>
+        <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="all" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="all" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Common\Serialization\" />
-  </ItemGroup>
+    <ItemGroup>
+        <Folder Include="Common\Serialization\" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <None Include="..\..\docs\images\active-login-logo-fingerprint-blue-v2-256x256.png" Pack="True" PackagePath="icon.png" />
-    <None Include="..\..\LICENSE.md" Pack="True" PackagePath="LICENSE.md" />
-  </ItemGroup>
+    <ItemGroup>
+        <None Include="..\..\docs\images\active-login-logo-fingerprint-blue-v2-256x256.png" Pack="True" PackagePath="icon.png" />
+        <None Include="..\..\LICENSE.md" Pack="True" PackagePath="LICENSE.md" />
+        <None Include="README.md" Pack="True" PackagePath="README.md" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <Compile Include="..\ActiveLogin.Authentication.Common\Serialization\SystemRuntimeJsonSerializer.cs" Link="Common\Serialization\SystemRuntimeJsonSerializer.cs" />
-  </ItemGroup>
+    <ItemGroup>
+        <Compile Include="..\ActiveLogin.Authentication.Common\Serialization\SystemRuntimeJsonSerializer.cs" Link="Common\Serialization\SystemRuntimeJsonSerializer.cs" />
+    </ItemGroup>
 </Project>

--- a/src/ActiveLogin.Authentication.BankId.Api/ActiveLogin.Authentication.BankId.Api.csproj
+++ b/src/ActiveLogin.Authentication.BankId.Api/ActiveLogin.Authentication.BankId.Api.csproj
@@ -28,7 +28,6 @@
         <PackageProjectUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication</PackageProjectUrl>
         <PackageIcon>icon.png</PackageIcon>
         <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
-        <PackageReadmeFile>readme.md</PackageReadmeFile>
 
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication.git</RepositoryUrl>
@@ -50,7 +49,7 @@
     <ItemGroup>
         <None Include="..\..\docs\images\active-login-logo-fingerprint-blue-v2-256x256.png" Pack="True" PackagePath="icon.png" />
         <None Include="..\..\LICENSE.md" Pack="True" PackagePath="LICENSE.md" />
-        <None Include="readme.md" Pack="True" PackagePath="readme.md" />
+        <None Include="readme.md" Pack="True" PackagePath="readme.txt" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/ActiveLogin.Authentication.BankId.Api/ActiveLogin.Authentication.BankId.Api.csproj
+++ b/src/ActiveLogin.Authentication.BankId.Api/ActiveLogin.Authentication.BankId.Api.csproj
@@ -29,7 +29,6 @@
         <PackageIcon>icon.png</PackageIcon>
         <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
         <PackageReadmeFile>readme.md</PackageReadmeFile>
-        <NuspecProperties>readme=readme.md</NuspecProperties>
 
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication.git</RepositoryUrl>

--- a/src/ActiveLogin.Authentication.BankId.Api/ActiveLogin.Authentication.BankId.Api.csproj
+++ b/src/ActiveLogin.Authentication.BankId.Api/ActiveLogin.Authentication.BankId.Api.csproj
@@ -50,7 +50,7 @@
     <ItemGroup>
         <None Include="..\..\docs\images\active-login-logo-fingerprint-blue-v2-256x256.png" Pack="True" PackagePath="icon.png" />
         <None Include="..\..\LICENSE.md" Pack="True" PackagePath="LICENSE.md" />
-        <None Include="README.md" Pack="True" PackagePath="README.md" />
+        <None Include="readme.md" Pack="True" PackagePath="readme.md" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/ActiveLogin.Authentication.BankId.Api/ActiveLogin.Authentication.BankId.Api.csproj
+++ b/src/ActiveLogin.Authentication.BankId.Api/ActiveLogin.Authentication.BankId.Api.csproj
@@ -11,7 +11,7 @@
         <PackageId>ActiveLogin.Authentication.BankId.Api</PackageId>
 
         <VersionPrefix>3.0.0</VersionPrefix>
-        <VersionSuffix>beta-2</VersionSuffix>
+        <VersionSuffix>beta-3</VersionSuffix>
         <AssemblyVersion>3.0.0.0</AssemblyVersion>
         <FileVersion Condition="'$(BUILD_BUILDNUMBER)' == ''">$(VersionPrefix).0</FileVersion>
         <FileVersion Condition="'$(BUILD_BUILDNUMBER)' != ''">$(VersionPrefix).$(BUILD_BUILDNUMBER)</FileVersion>

--- a/src/ActiveLogin.Authentication.BankId.Api/README.md
+++ b/src/ActiveLogin.Authentication.BankId.Api/README.md
@@ -1,4 +1,4 @@
-[![License: MIT](https://img.shields.io/badge/License-MIT-orange.svg)](https://opensource.org/licenses/MIT) [![Slack](https://img.shields.io/badge/slack-@ActiveLogin-blue.svg?logo=slack)](https://join.slack.com/t/activelogin/shared_invite/enQtODQ0ODYyMTgxMjg0LWJhODhiZmFmODYyMWMzZWEwMjdmYWU2NGRhZmQ0MTg0MzIwNzA2OTM3NTJjOTk2MmE1MzIwMzkzYjllMjAyNzg) [![Twitter Follow](https://img.shields.io/badge/Twitter-@ActiveLoginSE-blue.svg?logo=twitter)](https://twitter.com/ActiveLoginSE)
+# ActiveLogin.Authentication.BankId.Api
 
 ActiveLogin.Authentication enables an application to support Swedish BankID (svenskt BankID) authentication in .NET. Built on NET Standard and packaged as NuGet-packages they are easy to install and use on multiple platforms. Used with Identity Server it can be configured as a provider for Azure AD B2C. Free to use, [commercial support and traning](https://activelogin.net/#support) is available if you need assistance or a quick start. 
 
@@ -21,3 +21,15 @@ public class BankIdApiClient : IBankIdApiClient
 ## Full documentation
 
 For full documentation and samples, see the Readme in our [GitHub repo](https://github.com/ActiveLogin/ActiveLogin.Authentication).
+
+## Active Login
+
+Active Login is an Open Source project built on .NET Core that makes it easy to integrate with leading Swedish authentication services like [BankID](https://www.bankid.com/).
+
+https://www.activelogin.net/
+
+## Active Solution
+
+Active Login is built, maintained and sponsored by Active Solution. Active Solution is located in Stockholm (Sweden) and provides IT consulting with focus on web, cloud and AI.
+
+https://www.activesolution.se/

--- a/src/ActiveLogin.Authentication.BankId.Api/README.md
+++ b/src/ActiveLogin.Authentication.BankId.Api/README.md
@@ -1,6 +1,6 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-orange.svg)](https://opensource.org/licenses/MIT) [![Slack](https://img.shields.io/badge/slack-@ActiveLogin-blue.svg?logo=slack)](https://join.slack.com/t/activelogin/shared_invite/enQtODQ0ODYyMTgxMjg0LWJhODhiZmFmODYyMWMzZWEwMjdmYWU2NGRhZmQ0MTg0MzIwNzA2OTM3NTJjOTk2MmE1MzIwMzkzYjllMjAyNzg) [![Twitter Follow](https://img.shields.io/badge/Twitter-@ActiveLoginSE-blue.svg?logo=twitter)](https://twitter.com/ActiveLoginSE)
 
-ActiveLogin.Authentication enables an application to support Swedish BankID (svenskt BankID) authentication in .NET. Built on NET Standard and packaged as NuGet-packages they are easy to install and use on multiple platforms. Used with Identity Server it can be configured as a provider for Azure AD B2C. Totally free to use! [Commercial support and traning](https://activelogin.net/#support) is available if you need assistance or a quick start. 
+ActiveLogin.Authentication enables an application to support Swedish BankID (svenskt BankID) authentication in .NET. Built on NET Standard and packaged as NuGet-packages they are easy to install and use on multiple platforms. Used with Identity Server it can be configured as a provider for Azure AD B2C. Free to use, [commercial support and traning](https://activelogin.net/#support) is available if you need assistance or a quick start. 
 
 ## Sample usage
 

--- a/src/ActiveLogin.Authentication.BankId.Api/README.md
+++ b/src/ActiveLogin.Authentication.BankId.Api/README.md
@@ -1,0 +1,23 @@
+[![License: MIT](https://img.shields.io/badge/License-MIT-orange.svg)](https://opensource.org/licenses/MIT) [![Slack](https://img.shields.io/badge/slack-@ActiveLogin-blue.svg?logo=slack)](https://join.slack.com/t/activelogin/shared_invite/enQtODQ0ODYyMTgxMjg0LWJhODhiZmFmODYyMWMzZWEwMjdmYWU2NGRhZmQ0MTg0MzIwNzA2OTM3NTJjOTk2MmE1MzIwMzkzYjllMjAyNzg) [![Twitter Follow](https://img.shields.io/badge/Twitter-@ActiveLoginSE-blue.svg?logo=twitter)](https://twitter.com/ActiveLoginSE)
+
+ActiveLogin.Authentication enables an application to support Swedish BankID (svenskt BankID) authentication in .NET. Built on NET Standard and packaged as NuGet-packages they are easy to install and use on multiple platforms. Used with Identity Server it can be configured as a provider for Azure AD B2C. Totally free to use! [Commercial support and traning](https://activelogin.net/#support) is available if you need assistance or a quick start. 
+
+## Sample usage
+
+The constructor for the api client takes an `HttpClient` and you need to configure that `HttpClient` with a `BaseAddress`, `Tls12`, client certificates etc. depending on your needs.
+
+The client have these public methods.
+
+```csharp
+public class BankIdApiClient : IBankIdApiClient
+{
+    public Task<AuthResponse> AuthAsync(AuthRequest request) { ... }
+    public Task<SignResponse> SignAsync(SignRequest request) { ... }
+    public Task<CollectResponse> CollectAsync(CollectRequest request) { ... }
+    public Task<CancelResponse> CancelAsync(CancelRequest request) { ... }
+}
+```
+
+## Full documentation
+
+For full documentation and samples, see the Readme in our [GitHub repo](https://github.com/ActiveLogin/ActiveLogin.Authentication).

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore.Azure/ActiveLogin.Authentication.BankId.AspNetCore.Azure.csproj
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore.Azure/ActiveLogin.Authentication.BankId.AspNetCore.Azure.csproj
@@ -1,56 +1,58 @@
-<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <Nullable>enable</Nullable>
-    <NeutralLanguage>en</NeutralLanguage>
-    <NoWarn>1701;1702;1591;CS7035</NoWarn>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+﻿<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <LangVersion>latest</LangVersion>
+        <Nullable>enable</Nullable>
+        <NeutralLanguage>en</NeutralLanguage>
+        <NoWarn>1701;1702;1591;CS7035</NoWarn>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
-    <AssemblyName>ActiveLogin.Authentication.BankId.AspNetCore.Azure</AssemblyName>
-    <PackageId>ActiveLogin.Authentication.BankId.AspNetCore.Azure</PackageId>
+        <AssemblyName>ActiveLogin.Authentication.BankId.AspNetCore.Azure</AssemblyName>
+        <PackageId>ActiveLogin.Authentication.BankId.AspNetCore.Azure</PackageId>
 
-    <VersionPrefix>3.0.0</VersionPrefix>
-    <VersionSuffix>beta-2</VersionSuffix>
-    <AssemblyVersion>3.0.0.0</AssemblyVersion>
-    <FileVersion Condition="'$(BUILD_BUILDNUMBER)' == ''">$(VersionPrefix).0</FileVersion>
-    <FileVersion Condition="'$(BUILD_BUILDNUMBER)' != ''">$(VersionPrefix).$(BUILD_BUILDNUMBER)</FileVersion>
+        <VersionPrefix>3.0.0</VersionPrefix>
+        <VersionSuffix>beta-2</VersionSuffix>
+        <AssemblyVersion>3.0.0.0</AssemblyVersion>
+        <FileVersion Condition="'$(BUILD_BUILDNUMBER)' == ''">$(VersionPrefix).0</FileVersion>
+        <FileVersion Condition="'$(BUILD_BUILDNUMBER)' != ''">$(VersionPrefix).$(BUILD_BUILDNUMBER)</FileVersion>
 
-    <Description>Azure integrations for ActiveLogin.Authentication.BankId.AspNetCore that enables an application to support Swedish BankID's (svenskt BankIDs) native authentication workflow.</Description>
-    <PackageTags>azure;bankid;swedish;sweden;aspnetcore;authentication</PackageTags>
+        <Description>Azure integrations for ActiveLogin.Authentication.BankId.AspNetCore that enables an application to support Swedish BankID's (svenskt BankIDs) native authentication workflow.</Description>
+        <PackageTags>azure;bankid;swedish;sweden;aspnetcore;authentication</PackageTags>
 
-    <Authors>Active Solution;Peter Örneholm;Nikolay Krondev;Elin Ohlsson;Robert Folkesson;Jakob Ehn</Authors>
-    <Copyright>Copyright © ActiveLogin</Copyright>
+        <Authors>Active Solution;Peter Örneholm;Nikolay Krondev;Elin Ohlsson;Robert Folkesson;Jakob Ehn</Authors>
+        <Copyright>Copyright © ActiveLogin</Copyright>
 
-    <PackageProjectUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication</PackageProjectUrl>
-    <PackageIcon>icon.png</PackageIcon>
-    <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
+        <PackageProjectUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication</PackageProjectUrl>
+        <PackageIcon>icon.png</PackageIcon>
+        <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
 
-    <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication.git</RepositoryUrl>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <RepositoryUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication.git</RepositoryUrl>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
 
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-  </PropertyGroup>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <EmbedUntrackedSources>true</EmbedUntrackedSources>
+        <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.1.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="all" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Azure.Identity" Version="1.1.0" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="all" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.0.0" />
-  </ItemGroup>
+    <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+        <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.0.0" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <None Include="..\..\docs\images\active-login-logo-fingerprint-blue-v2-256x256.png" Pack="True" PackagePath="icon.png" />
-    <None Include="..\..\LICENSE.md" Pack="True" PackagePath="LICENSE.md" />
-  </ItemGroup>
+    <ItemGroup>
+        <None Include="..\..\docs\images\active-login-logo-fingerprint-blue-v2-256x256.png" Pack="True" PackagePath="icon.png" />
+        <None Include="..\..\LICENSE.md" Pack="True" PackagePath="LICENSE.md" />
+        <None Include="README.md" Pack="True" PackagePath="README.md" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\ActiveLogin.Authentication.BankId.AspNetCore\ActiveLogin.Authentication.BankId.AspNetCore.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\ActiveLogin.Authentication.BankId.AspNetCore\ActiveLogin.Authentication.BankId.AspNetCore.csproj" />
+    </ItemGroup>
 </Project>

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore.Azure/ActiveLogin.Authentication.BankId.AspNetCore.Azure.csproj
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore.Azure/ActiveLogin.Authentication.BankId.AspNetCore.Azure.csproj
@@ -25,7 +25,8 @@
         <PackageProjectUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication</PackageProjectUrl>
         <PackageIcon>icon.png</PackageIcon>
         <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
-        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <PackageReadmeFile>readme.md</PackageReadmeFile>
+        <NuspecProperties>readme=readme.md</NuspecProperties>
 
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication.git</RepositoryUrl>

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore.Azure/ActiveLogin.Authentication.BankId.AspNetCore.Azure.csproj
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore.Azure/ActiveLogin.Authentication.BankId.AspNetCore.Azure.csproj
@@ -49,7 +49,7 @@
     <ItemGroup>
         <None Include="..\..\docs\images\active-login-logo-fingerprint-blue-v2-256x256.png" Pack="True" PackagePath="icon.png" />
         <None Include="..\..\LICENSE.md" Pack="True" PackagePath="LICENSE.md" />
-        <None Include="README.md" Pack="True" PackagePath="README.md" />
+        <None Include="readme.md" Pack="True" PackagePath="readme.md" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore.Azure/ActiveLogin.Authentication.BankId.AspNetCore.Azure.csproj
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore.Azure/ActiveLogin.Authentication.BankId.AspNetCore.Azure.csproj
@@ -25,7 +25,6 @@
         <PackageProjectUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication</PackageProjectUrl>
         <PackageIcon>icon.png</PackageIcon>
         <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
-        <PackageReadmeFile>readme.md</PackageReadmeFile>
 
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication.git</RepositoryUrl>
@@ -49,7 +48,7 @@
     <ItemGroup>
         <None Include="..\..\docs\images\active-login-logo-fingerprint-blue-v2-256x256.png" Pack="True" PackagePath="icon.png" />
         <None Include="..\..\LICENSE.md" Pack="True" PackagePath="LICENSE.md" />
-        <None Include="readme.md" Pack="True" PackagePath="readme.md" />
+        <None Include="readme.md" Pack="True" PackagePath="readme.txt" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore.Azure/ActiveLogin.Authentication.BankId.AspNetCore.Azure.csproj
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore.Azure/ActiveLogin.Authentication.BankId.AspNetCore.Azure.csproj
@@ -11,7 +11,7 @@
         <PackageId>ActiveLogin.Authentication.BankId.AspNetCore.Azure</PackageId>
 
         <VersionPrefix>3.0.0</VersionPrefix>
-        <VersionSuffix>beta-2</VersionSuffix>
+        <VersionSuffix>beta-3</VersionSuffix>
         <AssemblyVersion>3.0.0.0</AssemblyVersion>
         <FileVersion Condition="'$(BUILD_BUILDNUMBER)' == ''">$(VersionPrefix).0</FileVersion>
         <FileVersion Condition="'$(BUILD_BUILDNUMBER)' != ''">$(VersionPrefix).$(BUILD_BUILDNUMBER)</FileVersion>

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore.Azure/ActiveLogin.Authentication.BankId.AspNetCore.Azure.csproj
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore.Azure/ActiveLogin.Authentication.BankId.AspNetCore.Azure.csproj
@@ -26,7 +26,6 @@
         <PackageIcon>icon.png</PackageIcon>
         <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
         <PackageReadmeFile>readme.md</PackageReadmeFile>
-        <NuspecProperties>readme=readme.md</NuspecProperties>
 
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication.git</RepositoryUrl>

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore.Azure/README.md
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore.Azure/README.md
@@ -1,0 +1,40 @@
+[![License: MIT](https://img.shields.io/badge/License-MIT-orange.svg)](https://opensource.org/licenses/MIT) [![Slack](https://img.shields.io/badge/slack-@ActiveLogin-blue.svg?logo=slack)](https://join.slack.com/t/activelogin/shared_invite/enQtODQ0ODYyMTgxMjg0LWJhODhiZmFmODYyMWMzZWEwMjdmYWU2NGRhZmQ0MTg0MzIwNzA2OTM3NTJjOTk2MmE1MzIwMzkzYjllMjAyNzg) [![Twitter Follow](https://img.shields.io/badge/Twitter-@ActiveLoginSE-blue.svg?logo=twitter)](https://twitter.com/ActiveLoginSE)
+
+ActiveLogin.Authentication enables an application to support Swedish BankID (svenskt BankID) authentication in .NET. Built on NET Standard and packaged as NuGet-packages they are easy to install and use on multiple platforms. Used with Identity Server it can be configured as a provider for Azure AD B2C. Totally free to use! [Commercial support and traning](https://activelogin.net/#support) is available if you need assistance or a quick start. 
+
+## Sample usage
+
+Sample usage of the extension method to use client certificates for BankID from Azure KeyVault.
+
+Adds the `UseClientCertificateFromAzureKeyVault(...)` extension method.
+
+```csharp
+services
+    .AddAuthentication()
+    .AddBankId(builder =>
+    {
+        builder
+            .UseClientCertificateFromAzureKeyVault(Configuration.GetSection("ActiveLogin:BankId:ClientCertificate"));
+    });
+```
+
+The expected configuration looks like this:
+
+```json
+{
+    "ActiveLogin:BankId:ClientCertificate" {
+        "UseManagedIdentity": true,
+
+        "AzureAdTenantId": "",
+        "AzureAdClientId": "",
+        "AzureAdClientSecret": "",
+
+        "AzureKeyVaultUri": "TODO-ADD-YOUR-VALUE",
+        "AzureKeyVaultSecretKey": "TODO-ADD-YOUR-VALUE"
+    }
+}
+```
+
+## Full documentation
+
+For full documentation and samples, see the Readme in our [GitHub repo](https://github.com/ActiveLogin/ActiveLogin.Authentication).

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore.Azure/README.md
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore.Azure/README.md
@@ -1,6 +1,6 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-orange.svg)](https://opensource.org/licenses/MIT) [![Slack](https://img.shields.io/badge/slack-@ActiveLogin-blue.svg?logo=slack)](https://join.slack.com/t/activelogin/shared_invite/enQtODQ0ODYyMTgxMjg0LWJhODhiZmFmODYyMWMzZWEwMjdmYWU2NGRhZmQ0MTg0MzIwNzA2OTM3NTJjOTk2MmE1MzIwMzkzYjllMjAyNzg) [![Twitter Follow](https://img.shields.io/badge/Twitter-@ActiveLoginSE-blue.svg?logo=twitter)](https://twitter.com/ActiveLoginSE)
 
-ActiveLogin.Authentication enables an application to support Swedish BankID (svenskt BankID) authentication in .NET. Built on NET Standard and packaged as NuGet-packages they are easy to install and use on multiple platforms. Used with Identity Server it can be configured as a provider for Azure AD B2C. Totally free to use! [Commercial support and traning](https://activelogin.net/#support) is available if you need assistance or a quick start. 
+ActiveLogin.Authentication enables an application to support Swedish BankID (svenskt BankID) authentication in .NET. Built on NET Standard and packaged as NuGet-packages they are easy to install and use on multiple platforms. Used with Identity Server it can be configured as a provider for Azure AD B2C. Free to use, [commercial support and traning](https://activelogin.net/#support) is available if you need assistance or a quick start. 
 
 ## Sample usage
 

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore.Azure/README.md
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore.Azure/README.md
@@ -1,4 +1,4 @@
-[![License: MIT](https://img.shields.io/badge/License-MIT-orange.svg)](https://opensource.org/licenses/MIT) [![Slack](https://img.shields.io/badge/slack-@ActiveLogin-blue.svg?logo=slack)](https://join.slack.com/t/activelogin/shared_invite/enQtODQ0ODYyMTgxMjg0LWJhODhiZmFmODYyMWMzZWEwMjdmYWU2NGRhZmQ0MTg0MzIwNzA2OTM3NTJjOTk2MmE1MzIwMzkzYjllMjAyNzg) [![Twitter Follow](https://img.shields.io/badge/Twitter-@ActiveLoginSE-blue.svg?logo=twitter)](https://twitter.com/ActiveLoginSE)
+# ActiveLogin.Authentication.BankId.AspNetCore.Azure
 
 ActiveLogin.Authentication enables an application to support Swedish BankID (svenskt BankID) authentication in .NET. Built on NET Standard and packaged as NuGet-packages they are easy to install and use on multiple platforms. Used with Identity Server it can be configured as a provider for Azure AD B2C. Free to use, [commercial support and traning](https://activelogin.net/#support) is available if you need assistance or a quick start. 
 
@@ -38,3 +38,15 @@ The expected configuration looks like this:
 ## Full documentation
 
 For full documentation and samples, see the Readme in our [GitHub repo](https://github.com/ActiveLogin/ActiveLogin.Authentication).
+
+## Active Login
+
+Active Login is an Open Source project built on .NET Core that makes it easy to integrate with leading Swedish authentication services like [BankID](https://www.bankid.com/).
+
+https://www.activelogin.net/
+
+## Active Solution
+
+Active Login is built, maintained and sponsored by Active Solution. Active Solution is located in Stockholm (Sweden) and provides IT consulting with focus on web, cloud and AI.
+
+https://www.activesolution.se/

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore.QRCoder/ActiveLogin.Authentication.BankId.AspNetCore.QRCoder.csproj
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore.QRCoder/ActiveLogin.Authentication.BankId.AspNetCore.QRCoder.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
         <LangVersion>latest</LangVersion>
@@ -12,7 +12,7 @@
         <RootNamespace>ActiveLogin.Authentication.BankId.AspNetCore.QrCoder</RootNamespace>
 
         <VersionPrefix>3.0.0</VersionPrefix>
-        <VersionSuffix>beta-2</VersionSuffix>
+        <VersionSuffix>beta-3</VersionSuffix>
         <AssemblyVersion>3.0.0.0</AssemblyVersion>
         <FileVersion Condition="'$(BUILD_BUILDNUMBER)' == ''">$(VersionPrefix).0</FileVersion>
         <FileVersion Condition="'$(BUILD_BUILDNUMBER)' != ''">$(VersionPrefix).$(BUILD_BUILDNUMBER)</FileVersion>

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore.QRCoder/ActiveLogin.Authentication.BankId.AspNetCore.QRCoder.csproj
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore.QRCoder/ActiveLogin.Authentication.BankId.AspNetCore.QRCoder.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
         <LangVersion>latest</LangVersion>
@@ -48,7 +48,7 @@
     <ItemGroup>
         <None Include="..\..\docs\images\active-login-logo-fingerprint-blue-v2-256x256.png" Pack="True" PackagePath="icon.png" />
         <None Include="..\..\LICENSE.md" Pack="True" PackagePath="LICENSE.md" />
-        <None Include="README.md" Pack="True" PackagePath="README.md" />
+        <None Include="readme.md" Pack="True" PackagePath="readme.md" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore.QRCoder/ActiveLogin.Authentication.BankId.AspNetCore.QRCoder.csproj
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore.QRCoder/ActiveLogin.Authentication.BankId.AspNetCore.QRCoder.csproj
@@ -26,7 +26,8 @@
         <PackageProjectUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication</PackageProjectUrl>
         <PackageIcon>icon.png</PackageIcon>
         <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
-        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <PackageReadmeFile>readme.md</PackageReadmeFile>
+        <NuspecProperties>readme=readme.md</NuspecProperties>
 
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication.git</RepositoryUrl>

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore.QRCoder/ActiveLogin.Authentication.BankId.AspNetCore.QRCoder.csproj
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore.QRCoder/ActiveLogin.Authentication.BankId.AspNetCore.QRCoder.csproj
@@ -27,7 +27,6 @@
         <PackageIcon>icon.png</PackageIcon>
         <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
         <PackageReadmeFile>readme.md</PackageReadmeFile>
-        <NuspecProperties>readme=readme.md</NuspecProperties>
 
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication.git</RepositoryUrl>

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore.QRCoder/ActiveLogin.Authentication.BankId.AspNetCore.QRCoder.csproj
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore.QRCoder/ActiveLogin.Authentication.BankId.AspNetCore.QRCoder.csproj
@@ -1,56 +1,58 @@
-<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <Nullable>enable</Nullable>
-    <NeutralLanguage>en</NeutralLanguage>
-    <NoWarn>1701;1702;1591;CS7035</NoWarn>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+﻿<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <LangVersion>latest</LangVersion>
+        <Nullable>enable</Nullable>
+        <NeutralLanguage>en</NeutralLanguage>
+        <NoWarn>1701;1702;1591;CS7035</NoWarn>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
-    <AssemblyName>ActiveLogin.Authentication.BankId.AspNetCore.QRCoder</AssemblyName>
-    <PackageId>ActiveLogin.Authentication.BankId.AspNetCore.QRCoder</PackageId>
-    <RootNamespace>ActiveLogin.Authentication.BankId.AspNetCore.QrCoder</RootNamespace>
+        <AssemblyName>ActiveLogin.Authentication.BankId.AspNetCore.QRCoder</AssemblyName>
+        <PackageId>ActiveLogin.Authentication.BankId.AspNetCore.QRCoder</PackageId>
+        <RootNamespace>ActiveLogin.Authentication.BankId.AspNetCore.QrCoder</RootNamespace>
 
-    <VersionPrefix>3.0.0</VersionPrefix>
-    <VersionSuffix>beta-2</VersionSuffix>
-    <AssemblyVersion>3.0.0.0</AssemblyVersion>
-    <FileVersion Condition="'$(BUILD_BUILDNUMBER)' == ''">$(VersionPrefix).0</FileVersion>
-    <FileVersion Condition="'$(BUILD_BUILDNUMBER)' != ''">$(VersionPrefix).$(BUILD_BUILDNUMBER)</FileVersion>
+        <VersionPrefix>3.0.0</VersionPrefix>
+        <VersionSuffix>beta-2</VersionSuffix>
+        <AssemblyVersion>3.0.0.0</AssemblyVersion>
+        <FileVersion Condition="'$(BUILD_BUILDNUMBER)' == ''">$(VersionPrefix).0</FileVersion>
+        <FileVersion Condition="'$(BUILD_BUILDNUMBER)' != ''">$(VersionPrefix).$(BUILD_BUILDNUMBER)</FileVersion>
 
-    <Description>QR code generation for ActiveLogin.Authentication.BankId.AspNetCore using the QRCoder library.</Description>
-    <PackageTags>bankid;swedish;sweden;aspnetcore;authentication;qr</PackageTags>
+        <Description>QR code generation for ActiveLogin.Authentication.BankId.AspNetCore using the QRCoder library.</Description>
+        <PackageTags>bankid;swedish;sweden;aspnetcore;authentication;qr</PackageTags>
 
-    <Authors>Active Solution;Daniel Kvist;Peter Örneholm</Authors>
-    <Copyright>Copyright © ActiveLogin</Copyright>
+        <Authors>Active Solution;Daniel Kvist;Peter Örneholm</Authors>
+        <Copyright>Copyright © ActiveLogin</Copyright>
 
-    <PackageProjectUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication</PackageProjectUrl>
-    <PackageIcon>icon.png</PackageIcon>
-    <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
+        <PackageProjectUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication</PackageProjectUrl>
+        <PackageIcon>icon.png</PackageIcon>
+        <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
 
-    <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication.git</RepositoryUrl>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <RepositoryUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication.git</RepositoryUrl>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
 
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-  </PropertyGroup>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <EmbedUntrackedSources>true</EmbedUntrackedSources>
+        <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="all" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="all" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="QRCoder" Version="1.3.6" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="QRCoder" Version="1.3.6" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <None Include="..\..\docs\images\active-login-logo-fingerprint-blue-v2-256x256.png" Pack="True" PackagePath="icon.png" />
-    <None Include="..\..\LICENSE.md" Pack="True" PackagePath="LICENSE.md" />
-  </ItemGroup>
+    <ItemGroup>
+        <None Include="..\..\docs\images\active-login-logo-fingerprint-blue-v2-256x256.png" Pack="True" PackagePath="icon.png" />
+        <None Include="..\..\LICENSE.md" Pack="True" PackagePath="LICENSE.md" />
+        <None Include="README.md" Pack="True" PackagePath="README.md" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\ActiveLogin.Authentication.BankId.AspNetCore\ActiveLogin.Authentication.BankId.AspNetCore.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\ActiveLogin.Authentication.BankId.AspNetCore\ActiveLogin.Authentication.BankId.AspNetCore.csproj" />
+    </ItemGroup>
 
 </Project>

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore.QRCoder/ActiveLogin.Authentication.BankId.AspNetCore.QRCoder.csproj
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore.QRCoder/ActiveLogin.Authentication.BankId.AspNetCore.QRCoder.csproj
@@ -26,7 +26,6 @@
         <PackageProjectUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication</PackageProjectUrl>
         <PackageIcon>icon.png</PackageIcon>
         <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
-        <PackageReadmeFile>readme.md</PackageReadmeFile>
 
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication.git</RepositoryUrl>
@@ -48,7 +47,7 @@
     <ItemGroup>
         <None Include="..\..\docs\images\active-login-logo-fingerprint-blue-v2-256x256.png" Pack="True" PackagePath="icon.png" />
         <None Include="..\..\LICENSE.md" Pack="True" PackagePath="LICENSE.md" />
-        <None Include="readme.md" Pack="True" PackagePath="readme.md" />
+        <None Include="readme.md" Pack="True" PackagePath="readme.txt" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore.QRCoder/README.md
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore.QRCoder/README.md
@@ -1,4 +1,4 @@
-[![License: MIT](https://img.shields.io/badge/License-MIT-orange.svg)](https://opensource.org/licenses/MIT) [![Slack](https://img.shields.io/badge/slack-@ActiveLogin-blue.svg?logo=slack)](https://join.slack.com/t/activelogin/shared_invite/enQtODQ0ODYyMTgxMjg0LWJhODhiZmFmODYyMWMzZWEwMjdmYWU2NGRhZmQ0MTg0MzIwNzA2OTM3NTJjOTk2MmE1MzIwMzkzYjllMjAyNzg) [![Twitter Follow](https://img.shields.io/badge/Twitter-@ActiveLoginSE-blue.svg?logo=twitter)](https://twitter.com/ActiveLoginSE)
+# ActiveLogin.Authentication.BankId.AspNetCore.QRCoder
 
 ActiveLogin.Authentication enables an application to support Swedish BankID (svenskt BankID) authentication in .NET. Built on NET Standard and packaged as NuGet-packages they are easy to install and use on multiple platforms. Used with Identity Server it can be configured as a provider for Azure AD B2C. Free to use, [commercial support and traning](https://activelogin.net/#support) is available if you need assistance or a quick start. 
 
@@ -21,3 +21,15 @@ services
 ## Full documentation
 
 For full documentation and samples, see the Readme in our [GitHub repo](https://github.com/ActiveLogin/ActiveLogin.Authentication).
+
+## Active Login
+
+Active Login is an Open Source project built on .NET Core that makes it easy to integrate with leading Swedish authentication services like [BankID](https://www.bankid.com/).
+
+https://www.activelogin.net/
+
+## Active Solution
+
+Active Login is built, maintained and sponsored by Active Solution. Active Solution is located in Stockholm (Sweden) and provides IT consulting with focus on web, cloud and AI.
+
+https://www.activesolution.se/

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore.QRCoder/README.md
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore.QRCoder/README.md
@@ -1,0 +1,23 @@
+[![License: MIT](https://img.shields.io/badge/License-MIT-orange.svg)](https://opensource.org/licenses/MIT) [![Slack](https://img.shields.io/badge/slack-@ActiveLogin-blue.svg?logo=slack)](https://join.slack.com/t/activelogin/shared_invite/enQtODQ0ODYyMTgxMjg0LWJhODhiZmFmODYyMWMzZWEwMjdmYWU2NGRhZmQ0MTg0MzIwNzA2OTM3NTJjOTk2MmE1MzIwMzkzYjllMjAyNzg) [![Twitter Follow](https://img.shields.io/badge/Twitter-@ActiveLoginSE-blue.svg?logo=twitter)](https://twitter.com/ActiveLoginSE)
+
+ActiveLogin.Authentication enables an application to support Swedish BankID (svenskt BankID) authentication in .NET. Built on NET Standard and packaged as NuGet-packages they are easy to install and use on multiple platforms. Used with Identity Server it can be configured as a provider for Azure AD B2C. Totally free to use! [Commercial support and traning](https://activelogin.net/#support) is available if you need assistance or a quick start. 
+
+## Sample usage
+
+Sample usage of the extension method to use [QRCoder](https://github.com/codebude/QRCoder) as the QR code generator for BankID.
+
+Adds the `UseQrCoderQrCodeGenerator(UseQrCoderQrCodeGenerator)` extension method.
+
+```csharp
+services
+    .AddAuthentication()
+    .AddBankId(builder =>
+    {
+        builder
+            .UseQrCoderQrCodeGenerator();
+    });
+```
+
+## Full documentation
+
+For full documentation and samples, see the Readme in our [GitHub repo](https://github.com/ActiveLogin/ActiveLogin.Authentication).

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore.QRCoder/README.md
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore.QRCoder/README.md
@@ -1,6 +1,6 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-orange.svg)](https://opensource.org/licenses/MIT) [![Slack](https://img.shields.io/badge/slack-@ActiveLogin-blue.svg?logo=slack)](https://join.slack.com/t/activelogin/shared_invite/enQtODQ0ODYyMTgxMjg0LWJhODhiZmFmODYyMWMzZWEwMjdmYWU2NGRhZmQ0MTg0MzIwNzA2OTM3NTJjOTk2MmE1MzIwMzkzYjllMjAyNzg) [![Twitter Follow](https://img.shields.io/badge/Twitter-@ActiveLoginSE-blue.svg?logo=twitter)](https://twitter.com/ActiveLoginSE)
 
-ActiveLogin.Authentication enables an application to support Swedish BankID (svenskt BankID) authentication in .NET. Built on NET Standard and packaged as NuGet-packages they are easy to install and use on multiple platforms. Used with Identity Server it can be configured as a provider for Azure AD B2C. Totally free to use! [Commercial support and traning](https://activelogin.net/#support) is available if you need assistance or a quick start. 
+ActiveLogin.Authentication enables an application to support Swedish BankID (svenskt BankID) authentication in .NET. Built on NET Standard and packaged as NuGet-packages they are easy to install and use on multiple platforms. Used with Identity Server it can be configured as a provider for Azure AD B2C. Free to use, [commercial support and traning](https://activelogin.net/#support) is available if you need assistance or a quick start. 
 
 ## Sample usage
 

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/ActiveLogin.Authentication.BankId.AspNetCore.csproj
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/ActiveLogin.Authentication.BankId.AspNetCore.csproj
@@ -27,7 +27,8 @@
         <PackageProjectUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication</PackageProjectUrl>
         <PackageIcon>icon.png</PackageIcon>
         <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
-        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <PackageReadmeFile>readme.md</PackageReadmeFile>
+        <NuspecProperties>readme=readme.md</NuspecProperties>
 
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication.git</RepositoryUrl>

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/ActiveLogin.Authentication.BankId.AspNetCore.csproj
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/ActiveLogin.Authentication.BankId.AspNetCore.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
+<Project Sdk="Microsoft.NET.Sdk.Razor">
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
         <LangVersion>latest</LangVersion>
@@ -109,7 +109,7 @@
     <ItemGroup>
         <None Include="..\..\docs\images\active-login-logo-fingerprint-blue-v2-256x256.png" Pack="True" PackagePath="icon.png" />
         <None Include="..\..\LICENSE.md" Pack="True" PackagePath="LICENSE.md" />
-        <None Include="README.md" Pack="True" PackagePath="README.md" />
+        <None Include="readme.md" Pack="True" PackagePath="readme.md" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/ActiveLogin.Authentication.BankId.AspNetCore.csproj
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/ActiveLogin.Authentication.BankId.AspNetCore.csproj
@@ -27,7 +27,6 @@
         <PackageProjectUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication</PackageProjectUrl>
         <PackageIcon>icon.png</PackageIcon>
         <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
-        <PackageReadmeFile>readme.md</PackageReadmeFile>
 
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication.git</RepositoryUrl>
@@ -109,7 +108,7 @@
     <ItemGroup>
         <None Include="..\..\docs\images\active-login-logo-fingerprint-blue-v2-256x256.png" Pack="True" PackagePath="icon.png" />
         <None Include="..\..\LICENSE.md" Pack="True" PackagePath="LICENSE.md" />
-        <None Include="readme.md" Pack="True" PackagePath="readme.md" />
+        <None Include="readme.md" Pack="True" PackagePath="readme.txt" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/ActiveLogin.Authentication.BankId.AspNetCore.csproj
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/ActiveLogin.Authentication.BankId.AspNetCore.csproj
@@ -28,7 +28,6 @@
         <PackageIcon>icon.png</PackageIcon>
         <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
         <PackageReadmeFile>readme.md</PackageReadmeFile>
-        <NuspecProperties>readme=readme.md</NuspecProperties>
 
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication.git</RepositoryUrl>

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/ActiveLogin.Authentication.BankId.AspNetCore.csproj
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/ActiveLogin.Authentication.BankId.AspNetCore.csproj
@@ -1,121 +1,123 @@
-<Project Sdk="Microsoft.NET.Sdk.Razor">
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <Nullable>enable</Nullable>
-    <NeutralLanguage>en</NeutralLanguage>
-    <NoWarn>1701;1702;1591;CS7035</NoWarn>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <LangVersion>latest</LangVersion>
+        <Nullable>enable</Nullable>
+        <NeutralLanguage>en</NeutralLanguage>
+        <NoWarn>1701;1702;1591;CS7035</NoWarn>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
-    <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
+        <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 
-    <AssemblyName>ActiveLogin.Authentication.BankId.AspNetCore</AssemblyName>
-    <PackageId>ActiveLogin.Authentication.BankId.AspNetCore</PackageId>
+        <AssemblyName>ActiveLogin.Authentication.BankId.AspNetCore</AssemblyName>
+        <PackageId>ActiveLogin.Authentication.BankId.AspNetCore</PackageId>
 
-    <VersionPrefix>3.0.0</VersionPrefix>
-    <VersionSuffix>beta-2</VersionSuffix>
-    <AssemblyVersion>3.0.0.0</AssemblyVersion>
-    <FileVersion Condition="'$(BUILD_BUILDNUMBER)' == ''">$(VersionPrefix).0</FileVersion>
-    <FileVersion Condition="'$(BUILD_BUILDNUMBER)' != ''">$(VersionPrefix).$(BUILD_BUILDNUMBER)</FileVersion>
+        <VersionPrefix>3.0.0</VersionPrefix>
+        <VersionSuffix>beta-2</VersionSuffix>
+        <AssemblyVersion>3.0.0.0</AssemblyVersion>
+        <FileVersion Condition="'$(BUILD_BUILDNUMBER)' == ''">$(VersionPrefix).0</FileVersion>
+        <FileVersion Condition="'$(BUILD_BUILDNUMBER)' != ''">$(VersionPrefix).$(BUILD_BUILDNUMBER)</FileVersion>
 
-    <Description>ASP.NET Core authentication module that enables an application to support Swedish BankID's (svenskt BankIDs) authentication workflow.</Description>
-    <PackageTags>bankid;swedish;sweden;aspnetcore;authentication;netstandard</PackageTags>
+        <Description>ASP.NET Core authentication module that enables an application to support Swedish BankID's (svenskt BankIDs) authentication workflow.</Description>
+        <PackageTags>bankid;swedish;sweden;aspnetcore;authentication;netstandard</PackageTags>
 
-    <Authors>Active Solution;Peter Örneholm;Nikolay Krondev;Elin Ohlsson;Robert Folkesson;Jakob Ehn</Authors>
-    <Copyright>Copyright © ActiveLogin</Copyright>
+        <Authors>Active Solution;Peter Örneholm;Nikolay Krondev;Elin Ohlsson;Robert Folkesson;Jakob Ehn</Authors>
+        <Copyright>Copyright © ActiveLogin</Copyright>
 
-    <PackageProjectUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication</PackageProjectUrl>
-    <PackageIcon>icon.png</PackageIcon>
-    <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
+        <PackageProjectUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication</PackageProjectUrl>
+        <PackageIcon>icon.png</PackageIcon>
+        <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
 
-    <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication.git</RepositoryUrl>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <RepositoryUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication.git</RepositoryUrl>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
 
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-  </PropertyGroup>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <EmbedUntrackedSources>true</EmbedUntrackedSources>
+        <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="all" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="all" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.0" />
+    <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.0" />
 
-    <PackageReference Include="ActiveLogin.Identity.Swedish" Version="2.0.2" />
-  </ItemGroup>
+        <PackageReference Include="ActiveLogin.Identity.Swedish" Version="2.0.2" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\ActiveLogin.Authentication.BankId.Api\ActiveLogin.Authentication.BankId.Api.csproj" />
-  </ItemGroup>
-  
-  <ItemGroup>
-    <Content Update="Areas\BankIdAuthentication\Views\BankId\Login.cshtml">
-      <Pack>$(IncludeRazorContentInPack)</Pack>
-    </Content>
-    <Content Update="Areas\BankIdAuthentication\Views\BankId\_Login.cshtml">
-      <Pack>$(IncludeRazorContentInPack)</Pack>
-    </Content>
-    <Content Update="Areas\BankIdAuthentication\Views\BankId\_LoginForm.cshtml">
-      <Pack>$(IncludeRazorContentInPack)</Pack>
-    </Content>
-    <Content Update="Areas\BankIdAuthentication\Views\BankId\_LoginStyle.cshtml">
-      <Pack>$(IncludeRazorContentInPack)</Pack>
-    </Content>
-    <Content Update="Areas\BankIdAuthentication\Views\BankId\_LoginScript.cshtml">
-      <Pack>$(IncludeRazorContentInPack)</Pack>
-    </Content>
-    <Content Update="Areas\BankIdAuthentication\Views\BankId\_LoginStatus.cshtml">
-      <Pack>$(IncludeRazorContentInPack)</Pack>
-    </Content>
-    <Content Update="Areas\BankIdAuthentication\Views\_ViewImports.cshtml">
-      <Pack>$(IncludeRazorContentInPack)</Pack>
-    </Content>
-    <Content Update="Areas\BankIdAuthentication\Views\_ViewStart.cshtml">
-      <Pack>$(IncludeRazorContentInPack)</Pack>
-    </Content>
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\ActiveLogin.Authentication.BankId.Api\ActiveLogin.Authentication.BankId.Api.csproj" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <EmbeddedResource Update="Resources\BankIdHandler.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>BankIdHandler.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
-    <EmbeddedResource Update="Resources\BankIdHandler.sv.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-    </EmbeddedResource>
-    <None Remove="Resources\qr-default-en.png" />
-    <EmbeddedResource Include="Resources\qr-default-en.png">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </EmbeddedResource>
-    <None Remove="Resources\qr-default-sv.png" />
-    <EmbeddedResource Include="Resources\qr-default-sv.png">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </EmbeddedResource>
-  </ItemGroup>
+    <ItemGroup>
+        <Content Update="Areas\BankIdAuthentication\Views\BankId\Login.cshtml">
+            <Pack>$(IncludeRazorContentInPack)</Pack>
+        </Content>
+        <Content Update="Areas\BankIdAuthentication\Views\BankId\_Login.cshtml">
+            <Pack>$(IncludeRazorContentInPack)</Pack>
+        </Content>
+        <Content Update="Areas\BankIdAuthentication\Views\BankId\_LoginForm.cshtml">
+            <Pack>$(IncludeRazorContentInPack)</Pack>
+        </Content>
+        <Content Update="Areas\BankIdAuthentication\Views\BankId\_LoginStyle.cshtml">
+            <Pack>$(IncludeRazorContentInPack)</Pack>
+        </Content>
+        <Content Update="Areas\BankIdAuthentication\Views\BankId\_LoginScript.cshtml">
+            <Pack>$(IncludeRazorContentInPack)</Pack>
+        </Content>
+        <Content Update="Areas\BankIdAuthentication\Views\BankId\_LoginStatus.cshtml">
+            <Pack>$(IncludeRazorContentInPack)</Pack>
+        </Content>
+        <Content Update="Areas\BankIdAuthentication\Views\_ViewImports.cshtml">
+            <Pack>$(IncludeRazorContentInPack)</Pack>
+        </Content>
+        <Content Update="Areas\BankIdAuthentication\Views\_ViewStart.cshtml">
+            <Pack>$(IncludeRazorContentInPack)</Pack>
+        </Content>
+    </ItemGroup>
 
-  <ItemGroup>
-    <Compile Update="Resources\BankIdHandler.Designer.cs">
-      <DependentUpon>BankIdHandler.resx</DependentUpon>
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-    </Compile>
-  </ItemGroup>
+    <ItemGroup>
+        <EmbeddedResource Update="Resources\BankIdHandler.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>BankIdHandler.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="Resources\BankIdHandler.sv.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+        </EmbeddedResource>
+        <None Remove="Resources\qr-default-en.png" />
+        <EmbeddedResource Include="Resources\qr-default-en.png">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </EmbeddedResource>
+        <None Remove="Resources\qr-default-sv.png" />
+        <EmbeddedResource Include="Resources\qr-default-sv.png">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </EmbeddedResource>
+    </ItemGroup>
 
-  <ItemGroup>
-    <None Include="..\..\docs\images\active-login-logo-fingerprint-blue-v2-256x256.png" Pack="True" PackagePath="icon.png" />
-    <None Include="..\..\LICENSE.md" Pack="True" PackagePath="LICENSE.md" />
-  </ItemGroup>
+    <ItemGroup>
+        <Compile Update="Resources\BankIdHandler.Designer.cs">
+            <DependentUpon>BankIdHandler.resx</DependentUpon>
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+        </Compile>
+    </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Common\Serialization\" />
-  </ItemGroup>
+    <ItemGroup>
+        <None Include="..\..\docs\images\active-login-logo-fingerprint-blue-v2-256x256.png" Pack="True" PackagePath="icon.png" />
+        <None Include="..\..\LICENSE.md" Pack="True" PackagePath="LICENSE.md" />
+        <None Include="README.md" Pack="True" PackagePath="README.md" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <Compile Include="..\ActiveLogin.Authentication.Common\Serialization\SystemRuntimeJsonSerializer.cs" Link="Common\Serialization\SystemRuntimeJsonSerializer.cs" />
-    <Compile Include="..\ActiveLogin.Authentication.Common\Serialization\JwtSerializer.cs" Link="Common\Serialization\JwtSerializer.cs" />
-  </ItemGroup>
+    <ItemGroup>
+        <Folder Include="Common\Serialization\" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Compile Include="..\ActiveLogin.Authentication.Common\Serialization\SystemRuntimeJsonSerializer.cs" Link="Common\Serialization\SystemRuntimeJsonSerializer.cs" />
+        <Compile Include="..\ActiveLogin.Authentication.Common\Serialization\JwtSerializer.cs" Link="Common\Serialization\JwtSerializer.cs" />
+    </ItemGroup>
 </Project>

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/ActiveLogin.Authentication.BankId.AspNetCore.csproj
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/ActiveLogin.Authentication.BankId.AspNetCore.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Razor">
+﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
         <LangVersion>latest</LangVersion>
@@ -13,7 +13,7 @@
         <PackageId>ActiveLogin.Authentication.BankId.AspNetCore</PackageId>
 
         <VersionPrefix>3.0.0</VersionPrefix>
-        <VersionSuffix>beta-2</VersionSuffix>
+        <VersionSuffix>beta-3</VersionSuffix>
         <AssemblyVersion>3.0.0.0</AssemblyVersion>
         <FileVersion Condition="'$(BUILD_BUILDNUMBER)' == ''">$(VersionPrefix).0</FileVersion>
         <FileVersion Condition="'$(BUILD_BUILDNUMBER)' != ''">$(VersionPrefix).$(BUILD_BUILDNUMBER)</FileVersion>

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/README.md
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/README.md
@@ -1,6 +1,6 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-orange.svg)](https://opensource.org/licenses/MIT) [![Slack](https://img.shields.io/badge/slack-@ActiveLogin-blue.svg?logo=slack)](https://join.slack.com/t/activelogin/shared_invite/enQtODQ0ODYyMTgxMjg0LWJhODhiZmFmODYyMWMzZWEwMjdmYWU2NGRhZmQ0MTg0MzIwNzA2OTM3NTJjOTk2MmE1MzIwMzkzYjllMjAyNzg) [![Twitter Follow](https://img.shields.io/badge/Twitter-@ActiveLoginSE-blue.svg?logo=twitter)](https://twitter.com/ActiveLoginSE)
 
-ActiveLogin.Authentication enables an application to support Swedish BankID (svenskt BankID) authentication in .NET. Built on NET Standard and packaged as NuGet-packages they are easy to install and use on multiple platforms. Used with Identity Server it can be configured as a provider for Azure AD B2C. Totally free to use! [Commercial support and traning](https://activelogin.net/#support) is available if you need assistance or a quick start. 
+ActiveLogin.Authentication enables an application to support Swedish BankID (svenskt BankID) authentication in .NET. Built on NET Standard and packaged as NuGet-packages they are easy to install and use on multiple platforms. Used with Identity Server it can be configured as a provider for Azure AD B2C. Free to use, [commercial support and traning](https://activelogin.net/#support) is available if you need assistance or a quick start. 
 
 ## Sample usage
 

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/README.md
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/README.md
@@ -1,4 +1,4 @@
-[![License: MIT](https://img.shields.io/badge/License-MIT-orange.svg)](https://opensource.org/licenses/MIT) [![Slack](https://img.shields.io/badge/slack-@ActiveLogin-blue.svg?logo=slack)](https://join.slack.com/t/activelogin/shared_invite/enQtODQ0ODYyMTgxMjg0LWJhODhiZmFmODYyMWMzZWEwMjdmYWU2NGRhZmQ0MTg0MzIwNzA2OTM3NTJjOTk2MmE1MzIwMzkzYjllMjAyNzg) [![Twitter Follow](https://img.shields.io/badge/Twitter-@ActiveLoginSE-blue.svg?logo=twitter)](https://twitter.com/ActiveLoginSE)
+# ActiveLogin.Authentication.BankId.AspNetCore
 
 ActiveLogin.Authentication enables an application to support Swedish BankID (svenskt BankID) authentication in .NET. Built on NET Standard and packaged as NuGet-packages they are easy to install and use on multiple platforms. Used with Identity Server it can be configured as a provider for Azure AD B2C. Free to use, [commercial support and traning](https://activelogin.net/#support) is available if you need assistance or a quick start. 
 
@@ -38,3 +38,15 @@ services
 ## Full documentation
 
 For full documentation and samples, see the Readme in our [GitHub repo](https://github.com/ActiveLogin/ActiveLogin.Authentication).
+
+## Active Login
+
+Active Login is an Open Source project built on .NET Core that makes it easy to integrate with leading Swedish authentication services like [BankID](https://www.bankid.com/).
+
+https://www.activelogin.net/
+
+## Active Solution
+
+Active Login is built, maintained and sponsored by Active Solution. Active Solution is located in Stockholm (Sweden) and provides IT consulting with focus on web, cloud and AI.
+
+https://www.activesolution.se/

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/README.md
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/README.md
@@ -1,0 +1,40 @@
+[![License: MIT](https://img.shields.io/badge/License-MIT-orange.svg)](https://opensource.org/licenses/MIT) [![Slack](https://img.shields.io/badge/slack-@ActiveLogin-blue.svg?logo=slack)](https://join.slack.com/t/activelogin/shared_invite/enQtODQ0ODYyMTgxMjg0LWJhODhiZmFmODYyMWMzZWEwMjdmYWU2NGRhZmQ0MTg0MzIwNzA2OTM3NTJjOTk2MmE1MzIwMzkzYjllMjAyNzg) [![Twitter Follow](https://img.shields.io/badge/Twitter-@ActiveLoginSE-blue.svg?logo=twitter)](https://twitter.com/ActiveLoginSE)
+
+ActiveLogin.Authentication enables an application to support Swedish BankID (svenskt BankID) authentication in .NET. Built on NET Standard and packaged as NuGet-packages they are easy to install and use on multiple platforms. Used with Identity Server it can be configured as a provider for Azure AD B2C. Totally free to use! [Commercial support and traning](https://activelogin.net/#support) is available if you need assistance or a quick start. 
+
+## Sample usage
+
+Sample usage of the ASP.NET Core authentication module.
+
+### Development
+
+```csharp
+services
+    .AddAuthentication()
+    .AddBankId(builder =>
+    {
+        builder
+            .UseSimulatedEnvironment()
+            .AddSameDevice();
+    });
+```
+
+### Production
+
+```csharp
+services
+    .AddAuthentication()
+    .AddBankId(builder =>
+    {
+        builder
+            .UseProductionEnvironment()
+            .UseClientCertificateFromAzureKeyVault(Configuration.GetSection("ActiveLogin:BankId:ClientCertificate"))
+            .AddSameDevice()
+            .AddOtherDevice()
+            .UseQrCoderQrCodeGenerator();
+    });
+```
+
+## Full documentation
+
+For full documentation and samples, see the Readme in our [GitHub repo](https://github.com/ActiveLogin/ActiveLogin.Authentication).

--- a/src/ActiveLogin.Authentication.GrandId.Api/ActiveLogin.Authentication.GrandId.Api.csproj
+++ b/src/ActiveLogin.Authentication.GrandId.Api/ActiveLogin.Authentication.GrandId.Api.csproj
@@ -28,7 +28,8 @@
         <PackageProjectUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication</PackageProjectUrl>
         <PackageIcon>icon.png</PackageIcon>
         <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
-        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <PackageReadmeFile>readme.md</PackageReadmeFile>
+        <NuspecProperties>readme=readme.md</NuspecProperties>
 
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication.git</RepositoryUrl>

--- a/src/ActiveLogin.Authentication.GrandId.Api/ActiveLogin.Authentication.GrandId.Api.csproj
+++ b/src/ActiveLogin.Authentication.GrandId.Api/ActiveLogin.Authentication.GrandId.Api.csproj
@@ -28,7 +28,6 @@
         <PackageProjectUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication</PackageProjectUrl>
         <PackageIcon>icon.png</PackageIcon>
         <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
-        <PackageReadmeFile>readme.md</PackageReadmeFile>
 
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication.git</RepositoryUrl>
@@ -50,7 +49,7 @@
     <ItemGroup>
         <None Include="..\..\docs\images\active-login-logo-fingerprint-blue-v2-256x256.png" Pack="True" PackagePath="icon.png" />
         <None Include="..\..\LICENSE.md" Pack="True" PackagePath="LICENSE.md" />
-        <None Include="readme.md" Pack="True" PackagePath="readme.md" />
+        <None Include="readme.md" Pack="True" PackagePath="readme.txt" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/ActiveLogin.Authentication.GrandId.Api/ActiveLogin.Authentication.GrandId.Api.csproj
+++ b/src/ActiveLogin.Authentication.GrandId.Api/ActiveLogin.Authentication.GrandId.Api.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <LangVersion>latest</LangVersion>
@@ -11,7 +11,7 @@
         <PackageId>ActiveLogin.Authentication.GrandId.Api</PackageId>
 
         <VersionPrefix>3.0.0</VersionPrefix>
-        <VersionSuffix>beta-2</VersionSuffix>
+        <VersionSuffix>beta-3</VersionSuffix>
         <AssemblyVersion>3.0.0.0</AssemblyVersion>
         <FileVersion Condition="'$(BUILD_BUILDNUMBER)' == ''">$(VersionPrefix).0</FileVersion>
         <FileVersion Condition="'$(BUILD_BUILDNUMBER)' != ''">$(VersionPrefix).$(BUILD_BUILDNUMBER)</FileVersion>

--- a/src/ActiveLogin.Authentication.GrandId.Api/ActiveLogin.Authentication.GrandId.Api.csproj
+++ b/src/ActiveLogin.Authentication.GrandId.Api/ActiveLogin.Authentication.GrandId.Api.csproj
@@ -29,7 +29,6 @@
         <PackageIcon>icon.png</PackageIcon>
         <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
         <PackageReadmeFile>readme.md</PackageReadmeFile>
-        <NuspecProperties>readme=readme.md</NuspecProperties>
 
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication.git</RepositoryUrl>

--- a/src/ActiveLogin.Authentication.GrandId.Api/ActiveLogin.Authentication.GrandId.Api.csproj
+++ b/src/ActiveLogin.Authentication.GrandId.Api/ActiveLogin.Authentication.GrandId.Api.csproj
@@ -1,57 +1,59 @@
-<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <Nullable>enable</Nullable>
-    <NeutralLanguage>en</NeutralLanguage>
-    <NoWarn>1701;1702;1591;CS7035</NoWarn>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+﻿<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <LangVersion>latest</LangVersion>
+        <Nullable>enable</Nullable>
+        <NeutralLanguage>en</NeutralLanguage>
+        <NoWarn>1701;1702;1591;CS7035</NoWarn>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
-    <AssemblyName>ActiveLogin.Authentication.GrandId.Api</AssemblyName>
-    <PackageId>ActiveLogin.Authentication.GrandId.Api</PackageId>
+        <AssemblyName>ActiveLogin.Authentication.GrandId.Api</AssemblyName>
+        <PackageId>ActiveLogin.Authentication.GrandId.Api</PackageId>
 
-    <VersionPrefix>3.0.0</VersionPrefix>
-    <VersionSuffix>beta-2</VersionSuffix>
-    <AssemblyVersion>3.0.0.0</AssemblyVersion>
-    <FileVersion Condition="'$(BUILD_BUILDNUMBER)' == ''">$(VersionPrefix).0</FileVersion>
-    <FileVersion Condition="'$(BUILD_BUILDNUMBER)' != ''">$(VersionPrefix).$(BUILD_BUILDNUMBER)</FileVersion>
+        <VersionPrefix>3.0.0</VersionPrefix>
+        <VersionSuffix>beta-2</VersionSuffix>
+        <AssemblyVersion>3.0.0.0</AssemblyVersion>
+        <FileVersion Condition="'$(BUILD_BUILDNUMBER)' == ''">$(VersionPrefix).0</FileVersion>
+        <FileVersion Condition="'$(BUILD_BUILDNUMBER)' != ''">$(VersionPrefix).$(BUILD_BUILDNUMBER)</FileVersion>
 
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>StrongNameKey.snk</AssemblyOriginatorKeyFile>
+        <SignAssembly>true</SignAssembly>
+        <AssemblyOriginatorKeyFile>StrongNameKey.snk</AssemblyOriginatorKeyFile>
 
-    <Description>API client that enables an application to call GrandID's (Svensk E-identitet) REST API in .NET.</Description>
-    <PackageTags>grandid;bankid;swedish;sweden;apiclient;netstandard</PackageTags>
+        <Description>API client that enables an application to call GrandID's (Svensk E-identitet) REST API in .NET.</Description>
+        <PackageTags>grandid;bankid;swedish;sweden;apiclient;netstandard</PackageTags>
 
-    <Authors>Active Solution;Martin Sjölander;Peter Örneholm;Fredrik Lundin;Conny Sjögren;Peter Carlsson;Robert Folkesson</Authors>
-    <Copyright>Copyright © ActiveLogin</Copyright>
+        <Authors>Active Solution;Martin Sjölander;Peter Örneholm;Fredrik Lundin;Conny Sjögren;Peter Carlsson;Robert Folkesson</Authors>
+        <Copyright>Copyright © ActiveLogin</Copyright>
 
-    <PackageProjectUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication</PackageProjectUrl>
-    <PackageIcon>icon.png</PackageIcon>
-    <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
+        <PackageProjectUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication</PackageProjectUrl>
+        <PackageIcon>icon.png</PackageIcon>
+        <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
 
-    <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication.git</RepositoryUrl>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <RepositoryUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication.git</RepositoryUrl>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
 
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-  </PropertyGroup>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <EmbedUntrackedSources>true</EmbedUntrackedSources>
+        <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="all" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="all" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Common\Serialization\" />
-  </ItemGroup>
+    <ItemGroup>
+        <Folder Include="Common\Serialization\" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <None Include="..\..\docs\images\active-login-logo-fingerprint-blue-v2-256x256.png" Pack="True" PackagePath="icon.png" />
-    <None Include="..\..\LICENSE.md" Pack="True" PackagePath="LICENSE.md" />
-  </ItemGroup>
+    <ItemGroup>
+        <None Include="..\..\docs\images\active-login-logo-fingerprint-blue-v2-256x256.png" Pack="True" PackagePath="icon.png" />
+        <None Include="..\..\LICENSE.md" Pack="True" PackagePath="LICENSE.md" />
+        <None Include="README.md" Pack="True" PackagePath="README.md" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <Compile Include="..\ActiveLogin.Authentication.Common\Serialization\SystemRuntimeJsonSerializer.cs" Link="Common\Serialization\SystemRuntimeJsonSerializer.cs" />
-  </ItemGroup>
+    <ItemGroup>
+        <Compile Include="..\ActiveLogin.Authentication.Common\Serialization\SystemRuntimeJsonSerializer.cs" Link="Common\Serialization\SystemRuntimeJsonSerializer.cs" />
+    </ItemGroup>
 </Project>

--- a/src/ActiveLogin.Authentication.GrandId.Api/ActiveLogin.Authentication.GrandId.Api.csproj
+++ b/src/ActiveLogin.Authentication.GrandId.Api/ActiveLogin.Authentication.GrandId.Api.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <LangVersion>latest</LangVersion>
@@ -50,7 +50,7 @@
     <ItemGroup>
         <None Include="..\..\docs\images\active-login-logo-fingerprint-blue-v2-256x256.png" Pack="True" PackagePath="icon.png" />
         <None Include="..\..\LICENSE.md" Pack="True" PackagePath="LICENSE.md" />
-        <None Include="README.md" Pack="True" PackagePath="README.md" />
+        <None Include="readme.md" Pack="True" PackagePath="readme.md" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/ActiveLogin.Authentication.GrandId.Api/README.md
+++ b/src/ActiveLogin.Authentication.GrandId.Api/README.md
@@ -1,0 +1,22 @@
+[![License: MIT](https://img.shields.io/badge/License-MIT-orange.svg)](https://opensource.org/licenses/MIT) [![Slack](https://img.shields.io/badge/slack-@ActiveLogin-blue.svg?logo=slack)](https://join.slack.com/t/activelogin/shared_invite/enQtODQ0ODYyMTgxMjg0LWJhODhiZmFmODYyMWMzZWEwMjdmYWU2NGRhZmQ0MTg0MzIwNzA2OTM3NTJjOTk2MmE1MzIwMzkzYjllMjAyNzg) [![Twitter Follow](https://img.shields.io/badge/Twitter-@ActiveLoginSE-blue.svg?logo=twitter)](https://twitter.com/ActiveLoginSE)
+
+ActiveLogin.Authentication enables an application to support Swedish BankID (svenskt BankID) authentication in .NET. Built on NET Standard and packaged as NuGet-packages they are easy to install and use on multiple platforms. Used with Identity Server it can be configured as a provider for Azure AD B2C. Totally free to use! [Commercial support and traning](https://activelogin.net/#support) is available if you need assistance or a quick start. 
+
+## Sample usage
+
+The constructor for the api client takes an `HttpClient` and you need to configure that `HttpClient` with a `BaseAddress` etc. depending on your needs.
+
+The client have these public methods.
+
+```csharp
+public class GrandIdApiClient : IGrandIdApiClient
+{
+    public async Task<BankIdFederatedLoginResponse> BankIdFederatedLoginAsync(BankIdFederatedLoginRequest request) { ... }
+    public async Task<BankIdGetSessionResponse> BankIdGetSessionAsync(BankIdGetSessionRequest request) { ... }
+    public async Task<LogoutResponse> LogoutAsync(LogoutRequest request) { ... }
+}
+```
+
+## Full documentation
+
+For full documentation and samples, see the Readme in our [GitHub repo](https://github.com/ActiveLogin/ActiveLogin.Authentication).

--- a/src/ActiveLogin.Authentication.GrandId.Api/README.md
+++ b/src/ActiveLogin.Authentication.GrandId.Api/README.md
@@ -1,6 +1,6 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-orange.svg)](https://opensource.org/licenses/MIT) [![Slack](https://img.shields.io/badge/slack-@ActiveLogin-blue.svg?logo=slack)](https://join.slack.com/t/activelogin/shared_invite/enQtODQ0ODYyMTgxMjg0LWJhODhiZmFmODYyMWMzZWEwMjdmYWU2NGRhZmQ0MTg0MzIwNzA2OTM3NTJjOTk2MmE1MzIwMzkzYjllMjAyNzg) [![Twitter Follow](https://img.shields.io/badge/Twitter-@ActiveLoginSE-blue.svg?logo=twitter)](https://twitter.com/ActiveLoginSE)
 
-ActiveLogin.Authentication enables an application to support Swedish BankID (svenskt BankID) authentication in .NET. Built on NET Standard and packaged as NuGet-packages they are easy to install and use on multiple platforms. Used with Identity Server it can be configured as a provider for Azure AD B2C. Totally free to use! [Commercial support and traning](https://activelogin.net/#support) is available if you need assistance or a quick start. 
+ActiveLogin.Authentication enables an application to support Swedish BankID (svenskt BankID) authentication in .NET. Built on NET Standard and packaged as NuGet-packages they are easy to install and use on multiple platforms. Used with Identity Server it can be configured as a provider for Azure AD B2C. Free to use, [commercial support and traning](https://activelogin.net/#support) is available if you need assistance or a quick start. 
 
 ## Sample usage
 

--- a/src/ActiveLogin.Authentication.GrandId.Api/README.md
+++ b/src/ActiveLogin.Authentication.GrandId.Api/README.md
@@ -1,4 +1,4 @@
-[![License: MIT](https://img.shields.io/badge/License-MIT-orange.svg)](https://opensource.org/licenses/MIT) [![Slack](https://img.shields.io/badge/slack-@ActiveLogin-blue.svg?logo=slack)](https://join.slack.com/t/activelogin/shared_invite/enQtODQ0ODYyMTgxMjg0LWJhODhiZmFmODYyMWMzZWEwMjdmYWU2NGRhZmQ0MTg0MzIwNzA2OTM3NTJjOTk2MmE1MzIwMzkzYjllMjAyNzg) [![Twitter Follow](https://img.shields.io/badge/Twitter-@ActiveLoginSE-blue.svg?logo=twitter)](https://twitter.com/ActiveLoginSE)
+# ActiveLogin.Authentication.GrandId.Api
 
 ActiveLogin.Authentication enables an application to support Swedish BankID (svenskt BankID) authentication in .NET. Built on NET Standard and packaged as NuGet-packages they are easy to install and use on multiple platforms. Used with Identity Server it can be configured as a provider for Azure AD B2C. Free to use, [commercial support and traning](https://activelogin.net/#support) is available if you need assistance or a quick start. 
 
@@ -20,3 +20,15 @@ public class GrandIdApiClient : IGrandIdApiClient
 ## Full documentation
 
 For full documentation and samples, see the Readme in our [GitHub repo](https://github.com/ActiveLogin/ActiveLogin.Authentication).
+
+## Active Login
+
+Active Login is an Open Source project built on .NET Core that makes it easy to integrate with leading Swedish authentication services like [BankID](https://www.bankid.com/).
+
+https://www.activelogin.net/
+
+## Active Solution
+
+Active Login is built, maintained and sponsored by Active Solution. Active Solution is located in Stockholm (Sweden) and provides IT consulting with focus on web, cloud and AI.
+
+https://www.activesolution.se/

--- a/src/ActiveLogin.Authentication.GrandId.AspNetCore/ActiveLogin.Authentication.GrandId.AspNetCore.csproj
+++ b/src/ActiveLogin.Authentication.GrandId.AspNetCore/ActiveLogin.Authentication.GrandId.AspNetCore.csproj
@@ -27,7 +27,8 @@
         <PackageProjectUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication</PackageProjectUrl>
         <PackageIcon>icon.png</PackageIcon>
         <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
-        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <PackageReadmeFile>readme.md</PackageReadmeFile>
+        <NuspecProperties>readme=readme.md</NuspecProperties>
 
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication.git</RepositoryUrl>

--- a/src/ActiveLogin.Authentication.GrandId.AspNetCore/ActiveLogin.Authentication.GrandId.AspNetCore.csproj
+++ b/src/ActiveLogin.Authentication.GrandId.AspNetCore/ActiveLogin.Authentication.GrandId.AspNetCore.csproj
@@ -1,67 +1,69 @@
-<Project Sdk="Microsoft.NET.Sdk.Razor">
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <Nullable>enable</Nullable>
-    <NeutralLanguage>en</NeutralLanguage>
-    <NoWarn>1701;1702;1591;CS7035</NoWarn>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <LangVersion>latest</LangVersion>
+        <Nullable>enable</Nullable>
+        <NeutralLanguage>en</NeutralLanguage>
+        <NoWarn>1701;1702;1591;CS7035</NoWarn>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
-    <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
+        <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 
-    <AssemblyName>ActiveLogin.Authentication.GrandId.AspNetCore</AssemblyName>
-    <PackageId>ActiveLogin.Authentication.GrandId.AspNetCore</PackageId>
+        <AssemblyName>ActiveLogin.Authentication.GrandId.AspNetCore</AssemblyName>
+        <PackageId>ActiveLogin.Authentication.GrandId.AspNetCore</PackageId>
 
-    <VersionPrefix>3.0.0</VersionPrefix>
-    <VersionSuffix>beta-2</VersionSuffix>
-    <AssemblyVersion>3.0.0.0</AssemblyVersion>
-    <FileVersion Condition="'$(BUILD_BUILDNUMBER)' == ''">$(VersionPrefix).0</FileVersion>
-    <FileVersion Condition="'$(BUILD_BUILDNUMBER)' != ''">$(VersionPrefix).$(BUILD_BUILDNUMBER)</FileVersion>
+        <VersionPrefix>3.0.0</VersionPrefix>
+        <VersionSuffix>beta-2</VersionSuffix>
+        <AssemblyVersion>3.0.0.0</AssemblyVersion>
+        <FileVersion Condition="'$(BUILD_BUILDNUMBER)' == ''">$(VersionPrefix).0</FileVersion>
+        <FileVersion Condition="'$(BUILD_BUILDNUMBER)' != ''">$(VersionPrefix).$(BUILD_BUILDNUMBER)</FileVersion>
 
-    <Description>ASP.NET Core authentication module that enables an application to support GrandID's (Svensk E-identitet) authentication workflow.</Description>
-    <PackageTags>grandid;bankid;swedish;sweden;aspnetcore;authentication;netstandard</PackageTags>
+        <Description>ASP.NET Core authentication module that enables an application to support GrandID's (Svensk E-identitet) authentication workflow.</Description>
+        <PackageTags>grandid;bankid;swedish;sweden;aspnetcore;authentication;netstandard</PackageTags>
 
-    <Authors>Active Solution;Martin Sjölander;Peter Örneholm;Fredrik Lundin;Conny Sjögren;Peter Carlsson;Robert Folkesson</Authors>
-    <Copyright>Copyright © ActiveLogin</Copyright>
+        <Authors>Active Solution;Martin Sjölander;Peter Örneholm;Fredrik Lundin;Conny Sjögren;Peter Carlsson;Robert Folkesson</Authors>
+        <Copyright>Copyright © ActiveLogin</Copyright>
 
-    <PackageProjectUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication</PackageProjectUrl>
-    <PackageIcon>icon.png</PackageIcon>
-    <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
+        <PackageProjectUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication</PackageProjectUrl>
+        <PackageIcon>icon.png</PackageIcon>
+        <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
 
-    <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication.git</RepositoryUrl>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <RepositoryUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication.git</RepositoryUrl>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
 
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-  </PropertyGroup>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <EmbedUntrackedSources>true</EmbedUntrackedSources>
+        <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="all" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="all" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.0" />
+    <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.0" />
 
-    <PackageReference Include="ActiveLogin.Identity.Swedish" Version="2.0.2" />
-  </ItemGroup>
+        <PackageReference Include="ActiveLogin.Identity.Swedish" Version="2.0.2" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\ActiveLogin.Authentication.GrandId.Api\ActiveLogin.Authentication.GrandId.Api.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\ActiveLogin.Authentication.GrandId.Api\ActiveLogin.Authentication.GrandId.Api.csproj" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Common\Serialization\" />
-  </ItemGroup>
+    <ItemGroup>
+        <Folder Include="Common\Serialization\" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <None Include="..\..\docs\images\active-login-logo-fingerprint-blue-v2-256x256.png" Pack="True" PackagePath="icon.png" />
-    <None Include="..\..\LICENSE.md" Pack="True" PackagePath="LICENSE.md" />
-  </ItemGroup>
+    <ItemGroup>
+        <None Include="..\..\docs\images\active-login-logo-fingerprint-blue-v2-256x256.png" Pack="True" PackagePath="icon.png" />
+        <None Include="..\..\LICENSE.md" Pack="True" PackagePath="LICENSE.md" />
+        <None Include="README.md" Pack="True" PackagePath="README.md" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <Compile Include="..\ActiveLogin.Authentication.Common\Serialization\JwtSerializer.cs" Link="Common\Serialization\JwtSerializer.cs" />
-  </ItemGroup>
+    <ItemGroup>
+        <Compile Include="..\ActiveLogin.Authentication.Common\Serialization\JwtSerializer.cs" Link="Common\Serialization\JwtSerializer.cs" />
+    </ItemGroup>
 </Project>

--- a/src/ActiveLogin.Authentication.GrandId.AspNetCore/ActiveLogin.Authentication.GrandId.AspNetCore.csproj
+++ b/src/ActiveLogin.Authentication.GrandId.AspNetCore/ActiveLogin.Authentication.GrandId.AspNetCore.csproj
@@ -28,7 +28,6 @@
         <PackageIcon>icon.png</PackageIcon>
         <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
         <PackageReadmeFile>readme.md</PackageReadmeFile>
-        <NuspecProperties>readme=readme.md</NuspecProperties>
 
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication.git</RepositoryUrl>

--- a/src/ActiveLogin.Authentication.GrandId.AspNetCore/ActiveLogin.Authentication.GrandId.AspNetCore.csproj
+++ b/src/ActiveLogin.Authentication.GrandId.AspNetCore/ActiveLogin.Authentication.GrandId.AspNetCore.csproj
@@ -27,7 +27,6 @@
         <PackageProjectUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication</PackageProjectUrl>
         <PackageIcon>icon.png</PackageIcon>
         <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
-        <PackageReadmeFile>readme.md</PackageReadmeFile>
 
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/ActiveLogin/ActiveLogin.Authentication.git</RepositoryUrl>
@@ -60,7 +59,7 @@
     <ItemGroup>
         <None Include="..\..\docs\images\active-login-logo-fingerprint-blue-v2-256x256.png" Pack="True" PackagePath="icon.png" />
         <None Include="..\..\LICENSE.md" Pack="True" PackagePath="LICENSE.md" />
-        <None Include="readme.md" Pack="True" PackagePath="readme.md" />
+        <None Include="readme.md" Pack="True" PackagePath="readme.txt" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/ActiveLogin.Authentication.GrandId.AspNetCore/ActiveLogin.Authentication.GrandId.AspNetCore.csproj
+++ b/src/ActiveLogin.Authentication.GrandId.AspNetCore/ActiveLogin.Authentication.GrandId.AspNetCore.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Razor">
+﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
         <LangVersion>latest</LangVersion>
@@ -13,7 +13,7 @@
         <PackageId>ActiveLogin.Authentication.GrandId.AspNetCore</PackageId>
 
         <VersionPrefix>3.0.0</VersionPrefix>
-        <VersionSuffix>beta-2</VersionSuffix>
+        <VersionSuffix>beta-3</VersionSuffix>
         <AssemblyVersion>3.0.0.0</AssemblyVersion>
         <FileVersion Condition="'$(BUILD_BUILDNUMBER)' == ''">$(VersionPrefix).0</FileVersion>
         <FileVersion Condition="'$(BUILD_BUILDNUMBER)' != ''">$(VersionPrefix).$(BUILD_BUILDNUMBER)</FileVersion>

--- a/src/ActiveLogin.Authentication.GrandId.AspNetCore/ActiveLogin.Authentication.GrandId.AspNetCore.csproj
+++ b/src/ActiveLogin.Authentication.GrandId.AspNetCore/ActiveLogin.Authentication.GrandId.AspNetCore.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
+<Project Sdk="Microsoft.NET.Sdk.Razor">
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
         <LangVersion>latest</LangVersion>
@@ -60,7 +60,7 @@
     <ItemGroup>
         <None Include="..\..\docs\images\active-login-logo-fingerprint-blue-v2-256x256.png" Pack="True" PackagePath="icon.png" />
         <None Include="..\..\LICENSE.md" Pack="True" PackagePath="LICENSE.md" />
-        <None Include="README.md" Pack="True" PackagePath="README.md" />
+        <None Include="readme.md" Pack="True" PackagePath="readme.md" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/ActiveLogin.Authentication.GrandId.AspNetCore/README.md
+++ b/src/ActiveLogin.Authentication.GrandId.AspNetCore/README.md
@@ -1,6 +1,6 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-orange.svg)](https://opensource.org/licenses/MIT) [![Slack](https://img.shields.io/badge/slack-@ActiveLogin-blue.svg?logo=slack)](https://join.slack.com/t/activelogin/shared_invite/enQtODQ0ODYyMTgxMjg0LWJhODhiZmFmODYyMWMzZWEwMjdmYWU2NGRhZmQ0MTg0MzIwNzA2OTM3NTJjOTk2MmE1MzIwMzkzYjllMjAyNzg) [![Twitter Follow](https://img.shields.io/badge/Twitter-@ActiveLoginSE-blue.svg?logo=twitter)](https://twitter.com/ActiveLoginSE)
 
-ActiveLogin.Authentication enables an application to support Swedish BankID (svenskt BankID) authentication in .NET. Built on NET Standard and packaged as NuGet-packages they are easy to install and use on multiple platforms. Used with Identity Server it can be configured as a provider for Azure AD B2C. Totally free to use! [Commercial support and traning](https://activelogin.net/#support) is available if you need assistance or a quick start. 
+ActiveLogin.Authentication enables an application to support Swedish BankID (svenskt BankID) authentication in .NET. Built on NET Standard and packaged as NuGet-packages they are easy to install and use on multiple platforms. Used with Identity Server it can be configured as a provider for Azure AD B2C. Free to use, [commercial support and traning](https://activelogin.net/#support) is available if you need assistance or a quick start. 
 
 ## Sample usage
 

--- a/src/ActiveLogin.Authentication.GrandId.AspNetCore/README.md
+++ b/src/ActiveLogin.Authentication.GrandId.AspNetCore/README.md
@@ -1,0 +1,42 @@
+[![License: MIT](https://img.shields.io/badge/License-MIT-orange.svg)](https://opensource.org/licenses/MIT) [![Slack](https://img.shields.io/badge/slack-@ActiveLogin-blue.svg?logo=slack)](https://join.slack.com/t/activelogin/shared_invite/enQtODQ0ODYyMTgxMjg0LWJhODhiZmFmODYyMWMzZWEwMjdmYWU2NGRhZmQ0MTg0MzIwNzA2OTM3NTJjOTk2MmE1MzIwMzkzYjllMjAyNzg) [![Twitter Follow](https://img.shields.io/badge/Twitter-@ActiveLoginSE-blue.svg?logo=twitter)](https://twitter.com/ActiveLoginSE)
+
+ActiveLogin.Authentication enables an application to support Swedish BankID (svenskt BankID) authentication in .NET. Built on NET Standard and packaged as NuGet-packages they are easy to install and use on multiple platforms. Used with Identity Server it can be configured as a provider for Azure AD B2C. Totally free to use! [Commercial support and traning](https://activelogin.net/#support) is available if you need assistance or a quick start. 
+
+## Sample usage
+
+Sample usage of the ASP.NET Core authentication module.
+
+### Development
+
+```csharp
+services
+    .AddAuthentication()
+    .AddGrandId(builder =>
+    {
+        builder
+            .UseSimulatedEnvironment()
+            .AddBankIdSameDevice(options => { })
+            .AddBankIdOtherDevice(options => { });
+    });
+```
+
+### Production
+
+```csharp
+services
+    .AddAuthentication()
+    .AddGrandId(builder =>
+    {
+        builder
+            .UseProductionEnvironment(config => {
+                config.ApiKey = Configuration.GetValue<string>("ActiveLogin:GrandId:ApiKey");
+                config.BankIdServiceKey = Configuration.GetValue<string>("ActiveLogin:GrandId:BankIdServiceKey");
+            })
+            .AddBankIdSameDevice()
+            .AddBankIdOtherDevice();
+    });
+```
+
+## Full documentation
+
+For full documentation and samples, see the Readme in our [GitHub repo](https://github.com/ActiveLogin/ActiveLogin.Authentication).

--- a/src/ActiveLogin.Authentication.GrandId.AspNetCore/README.md
+++ b/src/ActiveLogin.Authentication.GrandId.AspNetCore/README.md
@@ -1,4 +1,4 @@
-[![License: MIT](https://img.shields.io/badge/License-MIT-orange.svg)](https://opensource.org/licenses/MIT) [![Slack](https://img.shields.io/badge/slack-@ActiveLogin-blue.svg?logo=slack)](https://join.slack.com/t/activelogin/shared_invite/enQtODQ0ODYyMTgxMjg0LWJhODhiZmFmODYyMWMzZWEwMjdmYWU2NGRhZmQ0MTg0MzIwNzA2OTM3NTJjOTk2MmE1MzIwMzkzYjllMjAyNzg) [![Twitter Follow](https://img.shields.io/badge/Twitter-@ActiveLoginSE-blue.svg?logo=twitter)](https://twitter.com/ActiveLoginSE)
+# ActiveLogin.Authentication.GrandId.AspNetCore
 
 ActiveLogin.Authentication enables an application to support Swedish BankID (svenskt BankID) authentication in .NET. Built on NET Standard and packaged as NuGet-packages they are easy to install and use on multiple platforms. Used with Identity Server it can be configured as a provider for Azure AD B2C. Free to use, [commercial support and traning](https://activelogin.net/#support) is available if you need assistance or a quick start. 
 
@@ -40,3 +40,15 @@ services
 ## Full documentation
 
 For full documentation and samples, see the Readme in our [GitHub repo](https://github.com/ActiveLogin/ActiveLogin.Authentication).
+
+## Active Login
+
+Active Login is an Open Source project built on .NET Core that makes it easy to integrate with leading Swedish authentication services like [BankID](https://www.bankid.com/).
+
+https://www.activelogin.net/
+
+## Active Solution
+
+Active Login is built, maintained and sponsored by Active Solution. Active Solution is located in Stockholm (Sweden) and provides IT consulting with focus on web, cloud and AI.
+
+https://www.activesolution.se/


### PR DESCRIPTION
This PR fixes #165.

High level overview of this PR:

- [x] Add individual, smaller versions, of readme.txt to the packages

Turns out that the markdown integration on NuGet.org is manual only at this time.
The readme.md will be packed as readme.txt as that is the current format nuget in visual studio will undertand.

https://github.com/NuGet/Home/wiki/Packaging-Documentation-within-the-nupkg
