### PR TITLE
Add System.Text.Json implementation for serializer

### DIFF
--- a/src/ActiveLogin.Authentication.BankId.Api/ActiveLogin.Authentication.BankId.Api.csproj
+++ b/src/ActiveLogin.Authentication.BankId.Api/ActiveLogin.Authentication.BankId.Api.csproj
@@ -40,6 +40,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="all" />
+        <PackageReference Include="System.Text.Json" Version="4.7.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/ActiveLogin.Authentication.BankId.Api/BankIdHttpClientExtensions.cs
+++ b/src/ActiveLogin.Authentication.BankId.Api/BankIdHttpClientExtensions.cs
@@ -10,14 +10,14 @@ namespace ActiveLogin.Authentication.BankId.Api
     {
         public static async Task<TResult> PostAsync<TRequest, TResult>(this HttpClient httpClient, string url, TRequest request)
         {
-            var requestJson = SystemRuntimeJsonSerializer.Serialize(request);
+            var requestJson = await SystemRuntimeJsonSerializer.SerializeAsync(request);
             var requestContent = GetJsonStringContent(requestJson);
 
             var httpResponseMessage = await httpClient.PostAsync(url, requestContent).ConfigureAwait(false);
             await BankIdApiErrorHandler.EnsureSuccessAsync(httpResponseMessage).ConfigureAwait(false);
             var content = await httpResponseMessage.Content.ReadAsStreamAsync().ConfigureAwait(false);
 
-            return SystemRuntimeJsonSerializer.Deserialize<TResult>(content);
+            return await SystemRuntimeJsonSerializer.DeserializeAsync<TResult>(content);
         }
 
         private static StringContent GetJsonStringContent(string requestJson)

--- a/src/ActiveLogin.Authentication.BankId.Api/Errors/BankIdApiErrorHandler.cs
+++ b/src/ActiveLogin.Authentication.BankId.Api/Errors/BankIdApiErrorHandler.cs
@@ -34,7 +34,7 @@ namespace ActiveLogin.Authentication.BankId.Api.Errors
                 try
                 {
                     var content = await httpResponseMessage.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    return SystemRuntimeJsonSerializer.Deserialize<Error>(content);
+                    return await SystemRuntimeJsonSerializer.DeserializeAsync<Error>(content);
                 }
                 catch (Exception)
                 {

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Controllers/BankIdController.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Controllers/BankIdController.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using ActiveLogin.Authentication.BankId.Api.UserMessage;
 using ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthentication.Models;
 using ActiveLogin.Authentication.BankId.AspNetCore.DataProtection;
@@ -35,7 +36,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthenticatio
         }
 
         [HttpGet]
-        public ActionResult Login(string returnUrl, string loginOptions)
+        public async Task<IActionResult> Login(string returnUrl, string loginOptions)
         {
             if (!Url.IsLocalUrl(returnUrl))
             {
@@ -43,13 +44,13 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthenticatio
             }
 
             var unprotectedLoginOptions = _loginOptionsProtector.Unprotect(loginOptions);
-            var antiforgeryTokens = _antiforgery.GetAndStoreTokens(HttpContext);
+            var antiForgeryTokens = _antiforgery.GetAndStoreTokens(HttpContext);
 
-            var viewModel = GetLoginViewModel(returnUrl, loginOptions, unprotectedLoginOptions, antiforgeryTokens);
+            var viewModel = await GetLoginViewModelAsync(returnUrl, loginOptions, unprotectedLoginOptions, antiForgeryTokens);
             return View(viewModel);
         }
 
-        private BankIdLoginViewModel GetLoginViewModel(string returnUrl, string loginOptions, BankIdLoginOptions unprotectedLoginOptions, AntiforgeryTokenSet antiforgeryTokens)
+        private async Task<BankIdLoginViewModel> GetLoginViewModelAsync(string returnUrl, string loginOptions, BankIdLoginOptions unprotectedLoginOptions, AntiforgeryTokenSet antiforgeryTokens)
         {
             var initialStatusMessage = GetInitialStatusMessage(unprotectedLoginOptions);
             var loginScriptOptions = new BankIdLoginScriptOptions(
@@ -74,7 +75,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthenticatio
                 loginOptions,
                 unprotectedLoginOptions,
                 loginScriptOptions,
-                SystemRuntimeJsonSerializer.Serialize(loginScriptOptions),
+                await SystemRuntimeJsonSerializer.SerializeAsync(loginScriptOptions),
                 antiforgeryTokens.RequestToken
             );
         }

--- a/src/ActiveLogin.Authentication.Common/Serialization/SystemRuntimeJsonSerializer.cs
+++ b/src/ActiveLogin.Authentication.Common/Serialization/SystemRuntimeJsonSerializer.cs
@@ -1,40 +1,34 @@
 using System.IO;
-using System.Runtime.Serialization.Json;
 using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
 
 namespace ActiveLogin.Authentication.Common.Serialization
 {
-    internal static class SystemRuntimeJsonSerializer
+    public static class SystemRuntimeJsonSerializer
     {
-        public static T Deserialize<T>(string json)
+        public static async Task<T> DeserializeAsync<T>(string json)
         {
-            using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(json)))
-            {
-                var serializer = new DataContractJsonSerializer(typeof(T));
-                return (T)serializer.ReadObject(stream);
-            }
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+            return await JsonSerializer.DeserializeAsync<T>(stream).ConfigureAwait(false);
         }
 
-        public static T Deserialize<T>(Stream json)
+        public static async Task<T> DeserializeAsync<T>(Stream stream)
         {
-            var serializer = new DataContractJsonSerializer(typeof(T));
-            return (T)serializer.ReadObject(json);
+            return await JsonSerializer.DeserializeAsync<T>(stream).ConfigureAwait(false);
         }
 
-        public static string Serialize<T>(T value)
+        public static async Task<string> SerializeAsync<T>(T value)
         {
             if (value == null)
             {
                 return string.Empty;
             }
 
-            using (var stream = new MemoryStream())
-            {
-                var serializer = new DataContractJsonSerializer(typeof(T));
-                serializer.WriteObject(stream, value);
-                var json = stream.ToArray();
-                return Encoding.UTF8.GetString(json, 0, json.Length);
-            }
+            using var stream = new MemoryStream();
+            await JsonSerializer.SerializeAsync(stream, value).ConfigureAwait(false);
+            var json = stream.ToArray();
+            return Encoding.UTF8.GetString(json, 0, json.Length);
         }
     }
 }

--- a/src/ActiveLogin.Authentication.GrandId.Api/ActiveLogin.Authentication.GrandId.Api.csproj
+++ b/src/ActiveLogin.Authentication.GrandId.Api/ActiveLogin.Authentication.GrandId.Api.csproj
@@ -40,6 +40,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="all" />
+        <PackageReference Include="System.Text.Json" Version="4.7.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/ActiveLogin.Authentication.GrandId.Api/GrandIdHttpClientExtensions.cs
+++ b/src/ActiveLogin.Authentication.GrandId.Api/GrandIdHttpClientExtensions.cs
@@ -13,7 +13,7 @@ namespace ActiveLogin.Authentication.GrandId.Api
             var httpResponseMessage = await httpClient.GetAsync(url);
             var content = await httpResponseMessage.Content.ReadAsStreamAsync().ConfigureAwait(false);
 
-            return SystemRuntimeJsonSerializer.Deserialize<TResult>(content);
+            return await SystemRuntimeJsonSerializer.DeserializeAsync<TResult>(content);
         }
 
         public static async Task<TResult> PostAsync<TResult>(this HttpClient httpClient, string url, Dictionary<string, string?> postData)
@@ -23,7 +23,7 @@ namespace ActiveLogin.Authentication.GrandId.Api
             var httpResponseMessage = await httpClient.PostAsync(url, requestContent).ConfigureAwait(false);
             var content = await httpResponseMessage.Content.ReadAsStreamAsync().ConfigureAwait(false);
 
-            return SystemRuntimeJsonSerializer.Deserialize<TResult>(content);
+            return await SystemRuntimeJsonSerializer.DeserializeAsync<TResult>(content);
         }
 
         private static FormUrlEncodedContent GetFormUrlEncodedContent(Dictionary<string, string?> postData)

--- a/test/ActiveLogin.Authentication.BankId.Api.Test/Common/Serialization/SystemRuntimeJsonSerializer_Tests.cs
+++ b/test/ActiveLogin.Authentication.BankId.Api.Test/Common/Serialization/SystemRuntimeJsonSerializer_Tests.cs
@@ -1,0 +1,55 @@
+using System.Runtime.Serialization;
+using System.Threading.Tasks;
+using ActiveLogin.Authentication.Common.Serialization;
+using Xunit;
+
+namespace ActiveLogin.Authentication.BankId.Api.Test.Common.Serialization
+{
+    public class SystemRuntimeJsonSerializer_Tests
+    {
+        private const string SerializedObject = "{\"errorCode\":\"code\",\"details\":\"more\"}";
+
+        [DataContract]
+        internal class Error
+        {
+            public static Error Empty = new Error(string.Empty, string.Empty);
+
+            public Error(string errorCode, string details)
+            {
+                ErrorCode = errorCode;
+                Details = details;
+            }
+
+            [DataMember(Name = "errorCode")]
+            public string ErrorCode { get; private set; }
+
+            [DataMember(Name = "details")]
+            public string Details { get; private set; }
+        }
+
+        [Fact]
+        public async Task SerializeAsync__ShouldReturnString()
+        {
+            // Arrange
+            var model = new Error("code", "more");
+
+            // Act
+            var json = await SystemRuntimeJsonSerializer.SerializeAsync(model);
+
+            // Assert
+            Assert.Equal(SerializedObject, json);
+        }
+
+        [Fact]
+        public async Task DeserializeAsync__ShouldReturnErrorObject()
+        {
+            // Act
+            var error = await SystemRuntimeJsonSerializer.DeserializeAsync<Error>(SerializedObject);
+
+            // Assert
+            Assert.NotNull(error);
+            Assert.Equal("code", error.ErrorCode);
+            Assert.Equal("more", error.Details);
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes #200.

High level overview of this PR:

- [x] Use `System.Text.Json` implementation
- [x] Make all serializer methods asynchronous
- [ ] Fix parameterless constructor error for deserializer
- [ ] Verifies that Data attributes are supported