### PR TITLE
Change secret key to secret name for azure certificates

### DIFF
--- a/docs/getting-started-bankid.md
+++ b/docs/getting-started-bankid.md
@@ -41,16 +41,16 @@ These are only necessary if you plan to store your certificates in Azure KeyVaul
         "AzureAdClientSecret": "",
 
         "AzureKeyVaultUri": "TODO-ADD-YOUR-VALUE",
-        "AzureKeyVaultSecretKey": "TODO-ADD-YOUR-VALUE"
+        "AzureKeyVaultSecretName": "TODO-ADD-YOUR-VALUE"
     }
 }
 ```
 
 #### Certificates are secrets
 
-Note that when configuring the AzureKeyVaultSecretKey, the secret key should be the same as the name of the certificate in KeyVault. This is because key vault only exposes certificates with private keys as secrets.
+When configuring the AzureKeyVaultSecretName, the name is retrieved from the _Certificates_ rather than _Secrets_ in the Azure Portal. It is called a _secret_ in the API since this is how Azure Key Vault exposes certificates with private keys.
 
-You can read more about the reasonind behind this [in this blog post](https://azidentity.azurewebsites.net/post/2018/07/03/azure-key-vault-certificates-are-secrets) or in the very extensive [official documentation](https://docs.microsoft.com/en-gb/azure/key-vault/about-keys-secrets-and-certificates#BKMK_CompositionOfCertificate).
+You can read more about the reasoning behind this [in this blog post](https://azidentity.azurewebsites.net/post/2018/07/03/azure-key-vault-certificates-are-secrets) or in the very extensive [official documentation](https://docs.microsoft.com/en-gb/azure/key-vault/about-keys-secrets-and-certificates#BKMK_CompositionOfCertificate).
 
 ## Environments
 

--- a/samples/IdentityServer.ServerSample/appsettings.json
+++ b/samples/IdentityServer.ServerSample/appsettings.json
@@ -1,4 +1,4 @@
-{
+﻿{
     "Logging": {
         "IncludeScopes": false,
         "LogLevel": {
@@ -28,7 +28,7 @@
                 "AzureAdClientSecret": "",
 
                 "AzureKeyVaultUri": "",
-                "AzureKeyVaultSecretKey": ""
+                "AzureKeyVaultSecretName": ""
             }
         },
 

--- a/samples/Standalone.MvcSample/appsettings.json
+++ b/samples/Standalone.MvcSample/appsettings.json
@@ -19,7 +19,7 @@
                 "AzureAdClientSecret": "",
 
                 "AzureKeyVaultUri": "",
-                "AzureKeyVaultSecretKey": ""
+                "AzureKeyVaultSecretName": ""
             }
         },
 

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore.Azure/BankIdBuilderAzureExtensions.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore.Azure/BankIdBuilderAzureExtensions.cs
@@ -23,16 +23,16 @@ namespace Microsoft.Extensions.DependencyInjection
 
         public static IBankIdBuilder UseClientCertificateFromAzureKeyVault(this IBankIdBuilder builder, ClientCertificateFromAzureKeyVaultOptions options)
         {
-            if (string.IsNullOrWhiteSpace(options.AzureKeyVaultSecretKey))
+            if (string.IsNullOrWhiteSpace(options.AzureKeyVaultSecretName))
             {
-                throw new ArgumentException("AzureKeyVaultSecretKey is required");
+                throw new ArgumentException("AzureKeyVaultSecretName is required");
             }
 
             builder.UseClientCertificate(() =>
             {
                 var keyVaultCertificateClient = AzureKeyVaultCertificateClient.Create(options);
 
-                return keyVaultCertificateClient.GetX509Certificate2(options.AzureKeyVaultSecretKey);
+                return keyVaultCertificateClient.GetX509Certificate2(options.AzureKeyVaultSecretName);
             });
 
             return builder;

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore.Azure/ClientCertificateFromAzureKeyVaultOptions.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore.Azure/ClientCertificateFromAzureKeyVaultOptions.cs
@@ -1,4 +1,4 @@
-namespace ActiveLogin.Authentication.BankId.AspNetCore.Azure
+﻿namespace ActiveLogin.Authentication.BankId.AspNetCore.Azure
 {
     public class ClientCertificateFromAzureKeyVaultOptions
     {
@@ -9,6 +9,6 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Azure
         public string? AzureAdClientSecret { get; set; }
 
         public string? AzureKeyVaultUri { get; set; }
-        public string? AzureKeyVaultSecretKey { get; set; }
+        public string? AzureKeyVaultSecretName { get; set; }
     }
 }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore.Azure/readme.txt
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore.Azure/readme.txt
@@ -1,6 +1,6 @@
 # ActiveLogin.Authentication.BankId.AspNetCore.Azure
 
-ActiveLogin.Authentication enables an application to support Swedish BankID (svenskt BankID) authentication in .NET. Built on NET Standard and packaged as NuGet-packages they are easy to install and use on multiple platforms. Used with Identity Server it can be configured as a provider for Azure AD B2C. Free to use, [commercial support and training](https://activelogin.net/#support) is available if you need assistance or a quick start. 
+ActiveLogin.Authentication enables an application to support Swedish BankID (svenskt BankID) authentication in .NET. Built on NET Standard and packaged as NuGet-packages they are easy to install and use on multiple platforms. Used with Identity Server it can be configured as a provider for Azure AD B2C. Free to use, [commercial support and training](https://activelogin.net/#support) is available if you need assistance or a quick start.
 
 ## Sample usage
 
@@ -30,7 +30,7 @@ The expected configuration looks like this:
         "AzureAdClientSecret": "",
 
         "AzureKeyVaultUri": "TODO-ADD-YOUR-VALUE",
-        "AzureKeyVaultSecretKey": "TODO-ADD-YOUR-VALUE"
+        "AzureKeyVaultSecretName": "TODO-ADD-YOUR-VALUE"
     }
 }
 ```

--- a/test/ActiveLogin.Authentication.BankId.AspNetCore.Azure.Test/BankIdAuthenticationBuilderAzureExtensions_Tests.cs
+++ b/test/ActiveLogin.Authentication.BankId.AspNetCore.Azure.Test/BankIdAuthenticationBuilderAzureExtensions_Tests.cs
@@ -36,7 +36,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Azure.Test
                 var config = new Dictionary<string, string>
                 {
                     { "ActiveLogin:BankId:ClientCertificate:AzureKeyVaultUri", "someuri" },
-                    { "ActiveLogin:BankId:ClientCertificate:AzureKeyVaultSecretKey", "somekey" },
+                    { "ActiveLogin:BankId:ClientCertificate:AzureKeyVaultSecretName", "somename" },
                     { "ActiveLogin:BankId:ClientCertificate:UseManagedIdentity", "true" }
                 };
 
@@ -50,7 +50,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Azure.Test
             {
                 var config = new Dictionary<string, string>
                 {
-                    {"ActiveLogin:BankId:ClientCertificate:AzureKeyVaultSecretKey", ""},
+                    {"ActiveLogin:BankId:ClientCertificate:AzureKeyVaultSecretName", ""},
                 };
 
                 var exception = Assert.Throws<ArgumentException>(() =>
@@ -64,7 +64,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Azure.Test
                         });
                 });
 
-                Assert.Contains("AzureKeyVaultSecretKey", exception.Message);
+                Assert.Contains("AzureKeyVaultSecretName", exception.Message);
             }
 
             [Fact]
@@ -76,7 +76,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Azure.Test
                     { "ActiveLogin:BankId:ClientCertificate:AzureAdClientId", "id" },
                     { "ActiveLogin:BankId:ClientCertificate:AzureAdClientSecret", "clientsecret" },
                     { "ActiveLogin:BankId:ClientCertificate:AzureKeyVaultUri", "someuri" },
-                    { "ActiveLogin:BankId:ClientCertificate:AzureKeyVaultSecretKey", "somekey" },
+                    { "ActiveLogin:BankId:ClientCertificate:AzureKeyVaultSecretName", "somename" },
                     { "ActiveLogin:BankId:ClientCertificate:UseManagedIdentity", "false" }
                 };
 
@@ -96,7 +96,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Azure.Test
                     { "ActiveLogin:BankId:ClientCertificate:AzureAdClientId", "" },
                     { "ActiveLogin:BankId:ClientCertificate:AzureAdClientSecret", "clientsecret" },
                     { "ActiveLogin:BankId:ClientCertificate:AzureKeyVaultUri", "someuri" },
-                    { "ActiveLogin:BankId:ClientCertificate:AzureKeyVaultSecretKey", "somekey" },
+                    { "ActiveLogin:BankId:ClientCertificate:AzureKeyVaultSecretName", "somename" },
                     { "ActiveLogin:BankId:ClientCertificate:UseManagedIdentity", "false" }
                 };
 
@@ -115,7 +115,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Azure.Test
                     { "ActiveLogin:BankId:ClientCertificate:AzureAdClientId", "id" },
                     { "ActiveLogin:BankId:ClientCertificate:AzureAdClientSecret", "" },
                     { "ActiveLogin:BankId:ClientCertificate:AzureKeyVaultUri", "someuri" },
-                    { "ActiveLogin:BankId:ClientCertificate:AzureKeyVaultSecretKey", "somekey" },
+                    { "ActiveLogin:BankId:ClientCertificate:AzureKeyVaultSecretName", "somename" },
                     { "ActiveLogin:BankId:ClientCertificate:UseManagedIdentity", "false" }
                 };
 


### PR DESCRIPTION
This PR will clarify the naming of the certificate/secret name in
the options for using client certificates in Azure.

This PR fixes #208 .
