### PR TITLE
Make Cert data contract publicly available

### DIFF
--- a/src/ActiveLogin.Authentication.BankId.Api/Models/Cert.cs
+++ b/src/ActiveLogin.Authentication.BankId.Api/Models/Cert.cs
@@ -8,7 +8,7 @@ namespace ActiveLogin.Authentication.BankId.Api.Models
     [DataContract]
     public class Cert
     {
-        internal Cert(string notBefore, string notAfter)
+        public Cert(string notBefore, string notAfter)
         {
             NotBefore = notBefore;
             NotAfter = notAfter;


### PR DESCRIPTION
This PR will expose the Cert data contract constructor
so objects can be build outside of the package. This is needed
to be able to implement a custom simulated client for BankID.

This PR fixes #210 
