### PR TITLE
Fix bug with EndUserIp IPv4 mapped to IPv6

### DIFF
--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Controllers/BankIdApiController.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Controllers/BankIdApiController.cs
@@ -178,7 +178,8 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthenticatio
 
         private string GetEndUserIp()
         {
-            return HttpContext.Connection.RemoteIpAddress.ToString();
+            var remoteIp = HttpContext.Connection.RemoteIpAddress;
+            return (remoteIp.IsIPv4MappedToIPv6 ? remoteIp.MapToIPv4().ToString() : remoteIp.ToString());
         }
 
         private string GetBankIdRedirectUri(BankIdLoginApiInitializeRequest request, AuthResponse authResponse, BankIdSupportedDevice detectedDevice)


### PR DESCRIPTION
This PR fixes #213 

High level overview of this PR:

- [x] Fixes issue when hosted on docker/linux where the enduser IPv4 ip is mapped to IPv6 not accepted by BankID API.