### PR TITLE
Change redirect scheme for android (242)

### DIFF
--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Controllers/BankIdApiController.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Controllers/BankIdApiController.cs
@@ -149,7 +149,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthenticatio
         private static bool BrowserMightNotAutoLaunch(BankIdSupportedDevice detectedDevice)
         {
             // Some Android browsers might have issues launching a third party scheme (BankID) if there is no user interaction.
-            // Android version > 6 supports app links (https://app.bankid.com/)
+            // Android version > 6 supports app links (https://app.bankid.com/).
             return detectedDevice.DeviceOs == BankIdSupportedDeviceOs.Android && detectedDevice.DeviceOsVersion.MajorVersion < 6;
         }
 

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Controllers/BankIdApiController.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Controllers/BankIdApiController.cs
@@ -151,7 +151,8 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthenticatio
         private static bool BrowserMightNotAutoLaunch(BankIdSupportedDevice detectedDevice)
         {
             // Some Android browsers might have issues launching a third party scheme (BankID) if there is no user interaction.
-            return detectedDevice.DeviceOs == BankIdSupportedDeviceOs.Android;
+            // Android version > 6 supports app links (https://app.bankid.com/)
+            return detectedDevice.DeviceOs == BankIdSupportedDeviceOs.Android && detectedDevice.DeviceOsVersion.MajorVersion < 6;
         }
 
         private static bool BrowserWillReloadPageOnReturnRedirect(BankIdSupportedDevice detectedDevice)

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Launcher/BankIdLauncher.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Launcher/BankIdLauncher.cs
@@ -11,7 +11,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Launcher
     {
         private const string BankIdScheme = "bankid:///";
 
-        private const string IosUrlPrefix = "https://app.bankid.com/";
+        private const string UrlPrefix = "https://app.bankid.com/";
         private const string NullRedirectUrl = "null";
 
         private const string IosChromeScheme = "googlechromes://";
@@ -27,11 +27,13 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Launcher
 
         private string GetPrefixPart(BankIdSupportedDevice device)
         {
-            // Only Safari on IOS seems to support the app.bankid.com reference
-            if (device.DeviceOs == BankIdSupportedDeviceOs.Ios
+            // Only Safari on IOS and Android version >= 6 seems to support the app.bankid.com reference
+            if ((device.DeviceOs == BankIdSupportedDeviceOs.Ios
                 && device.DeviceBrowser == BankIdSupportedDeviceBrowser.Safari)
+                || (device.DeviceOs == BankIdSupportedDeviceOs.Android
+                && device.DeviceOsVersion.MajorVersion >= 6))
             {
-                return IosUrlPrefix;
+                return UrlPrefix;
             }
 
             return BankIdScheme;

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/SupportedDevice/BankIdSupportedDevice.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/SupportedDevice/BankIdSupportedDevice.cs
@@ -2,15 +2,18 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.SupportedDevice
 {
     public class BankIdSupportedDevice
     {
-        public BankIdSupportedDevice(BankIdSupportedDeviceType deviceType, BankIdSupportedDeviceOs deviceOs, BankIdSupportedDeviceBrowser deviceBrowser)
+        public BankIdSupportedDevice(BankIdSupportedDeviceType deviceType, BankIdSupportedDeviceOs deviceOs,
+            BankIdSupportedDeviceBrowser deviceBrowser, BankIdSupportedDeviceOsVersion deviceOsVersion)
         {
             DeviceType = deviceType;
             DeviceOs = deviceOs;
             DeviceBrowser = deviceBrowser;
+            DeviceOsVersion = deviceOsVersion;
         }
 
         public BankIdSupportedDeviceType DeviceType { get; }
         public BankIdSupportedDeviceOs DeviceOs { get; }
+        public BankIdSupportedDeviceOsVersion DeviceOsVersion { get; }
         public BankIdSupportedDeviceBrowser DeviceBrowser { get; }
     }
 }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/SupportedDevice/BankIdSupportedDeviceDetector.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/SupportedDevice/BankIdSupportedDeviceDetector.cs
@@ -10,10 +10,11 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.SupportedDevice
             var normalizedUserAgent = userAgent?.ToLower().Trim() ?? string.Empty;
 
             var deviceOs = GetDeviceOs(normalizedUserAgent);
+            var deviceOsVersion = GetDeviceOsVersion(normalizedUserAgent);
             var deviceBrowser = GetDeviceBrowser(normalizedUserAgent);
             var deviceType = GetDeviceType(deviceOs);
 
-            return new BankIdSupportedDevice(deviceType, deviceOs, deviceBrowser);
+            return new BankIdSupportedDevice(deviceType, deviceOs, deviceBrowser, deviceOsVersion);
         }
 
         private static BankIdSupportedDeviceType GetDeviceType(BankIdSupportedDeviceOs deviceOs)
@@ -59,6 +60,26 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.SupportedDevice
             }
 
             return BankIdSupportedDeviceOs.Unknown;
+        }
+
+        private static BankIdSupportedDeviceOsVersion GetDeviceOsVersion(string userAgent)
+        {
+            return IsAndroid(userAgent) ? GetAndroidVersion(userAgent) : new BankIdSupportedDeviceOsVersion();
+        }
+
+        private static BankIdSupportedDeviceOsVersion GetAndroidVersion(string userAgent)
+        {
+            var versionNumber = userAgent.Substring(userAgent.IndexOf("android") + "android".Length).Trim();
+            versionNumber = versionNumber.Substring(0, versionNumber.IndexOf(";"));
+            var versionNumberList = versionNumber.Split('.').Select(int.Parse).ToList();
+
+            return versionNumberList.Count switch
+            {
+                1 => new BankIdSupportedDeviceOsVersion(versionNumberList.ElementAt(0)),
+                2 => new BankIdSupportedDeviceOsVersion(versionNumberList.ElementAt(0), versionNumberList.ElementAt(1)),
+                3 => new BankIdSupportedDeviceOsVersion(versionNumberList.ElementAt(0), versionNumberList.ElementAt(1), versionNumberList.ElementAt(2)),
+                _ => new BankIdSupportedDeviceOsVersion()
+            };
         }
 
         private static BankIdSupportedDeviceBrowser GetDeviceBrowser(string userAgent)

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/SupportedDevice/BankIdSupportedDeviceDetector.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/SupportedDevice/BankIdSupportedDeviceDetector.cs
@@ -69,17 +69,26 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.SupportedDevice
 
         private static BankIdSupportedDeviceOsVersion GetAndroidVersion(string userAgent)
         {
-            var versionNumber = userAgent.Substring(userAgent.IndexOf("android") + "android".Length).Trim();
-            versionNumber = versionNumber.Substring(0, versionNumber.IndexOf(";"));
-            var versionNumberList = versionNumber.Split('.').Select(int.Parse).ToList();
-
-            return versionNumberList.Count switch
+            try
             {
-                1 => new BankIdSupportedDeviceOsVersion(versionNumberList.ElementAt(0)),
-                2 => new BankIdSupportedDeviceOsVersion(versionNumberList.ElementAt(0), versionNumberList.ElementAt(1)),
-                3 => new BankIdSupportedDeviceOsVersion(versionNumberList.ElementAt(0), versionNumberList.ElementAt(1), versionNumberList.ElementAt(2)),
-                _ => new BankIdSupportedDeviceOsVersion()
-            };
+                //Example userAgent for Android "Mozilla/5.0 (Linux; Android 6.0.1; SM-G532G Build/MMB29T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.83 Mobile Safari/537.36";
+                const string Android = "android";
+                var versionNumber = userAgent.Substring(userAgent.IndexOf(Android) + Android.Length).Trim();
+                versionNumber = versionNumber.Substring(0, versionNumber.IndexOf(";"));
+                var versionNumberList = versionNumber.Split('.').Select(v => int.TryParse(v, out var version) ? version : (int?)null).ToArray();
+
+                return versionNumberList.Length switch
+                {
+                    1 => new BankIdSupportedDeviceOsVersion(versionNumberList[0]),
+                    2 => new BankIdSupportedDeviceOsVersion(versionNumberList[0], versionNumberList[1]),
+                    3 => new BankIdSupportedDeviceOsVersion(versionNumberList[0], versionNumberList[1], versionNumberList[2]),
+                    _ => new BankIdSupportedDeviceOsVersion()
+                };
+            }
+            catch
+            {
+                return new BankIdSupportedDeviceOsVersion();
+            }
         }
 
         private static BankIdSupportedDeviceBrowser GetDeviceBrowser(string userAgent)

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/SupportedDevice/BankIdSupportedDeviceOsVersion.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/SupportedDevice/BankIdSupportedDeviceOsVersion.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace ActiveLogin.Authentication.BankId.AspNetCore.SupportedDevice
+{
+    public class BankIdSupportedDeviceOsVersion
+    {
+        public BankIdSupportedDeviceOsVersion(int majorVersion = 0, int minorVersion = 0, int patch = 0)
+        {
+            MajorVersion = majorVersion;
+            MinorVersion = minorVersion;
+            Patch = patch;
+        }
+
+        public int MajorVersion { get; } = 0;
+        public int MinorVersion { get; } = 0;
+        public int Patch { get;} = 0;
+    }
+}

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/SupportedDevice/BankIdSupportedDeviceOsVersion.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/SupportedDevice/BankIdSupportedDeviceOsVersion.cs
@@ -1,21 +1,16 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Text;
-
 namespace ActiveLogin.Authentication.BankId.AspNetCore.SupportedDevice
 {
     public class BankIdSupportedDeviceOsVersion
     {
-        public BankIdSupportedDeviceOsVersion(int majorVersion = 0, int minorVersion = 0, int patch = 0)
+        public BankIdSupportedDeviceOsVersion(int? majorVersion = null, int? minorVersion = null, int? patch = null)
         {
             MajorVersion = majorVersion;
             MinorVersion = minorVersion;
             Patch = patch;
         }
 
-        public int MajorVersion { get; } = 0;
-        public int MinorVersion { get; } = 0;
-        public int Patch { get;} = 0;
+        public int? MajorVersion { get; }
+        public int? MinorVersion { get; }
+        public int? Patch { get;}
     }
 }

--- a/test/ActiveLogin.Authentication.BankId.AspNetCore.Test/UserMessage/BankIdSupportedDeviceDetector_Detect_Tests.cs
+++ b/test/ActiveLogin.Authentication.BankId.AspNetCore.Test/UserMessage/BankIdSupportedDeviceDetector_Detect_Tests.cs
@@ -46,7 +46,6 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Test.UserMessage
             Assert.Equal(BankIdSupportedDeviceBrowser.Chrome, detectedDevice.DeviceBrowser);
         }
 
-
         [Fact]
         public void Should_Only_Detect_WindowsPhone_And_Mobile_When_WindowsPhone_User_Agent()
         {
@@ -213,6 +212,30 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Test.UserMessage
             Assert.Equal(BankIdSupportedDeviceType.Mobile, detectedDevice.DeviceType);
             Assert.Equal(BankIdSupportedDeviceOs.Android, detectedDevice.DeviceOs);
             Assert.Equal(BankIdSupportedDeviceBrowser.Edge, detectedDevice.DeviceBrowser);
+        }
+
+        [Fact]
+        public void Should_Detect_Os_Version_On_Android_When_Version_6_0_1()
+        {
+            var userAgent = "Mozilla/5.0 (Linux; Android 6.0.1; SM-G532G Build/MMB29T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.83 Mobile Safari/537.36";
+            var detectedDevice = _bankIdSupportedDeviceDetector.Detect(userAgent);
+
+            Assert.Equal(BankIdSupportedDeviceOs.Android, detectedDevice.DeviceOs);
+            Assert.Equal(6, detectedDevice.DeviceOsVersion.MajorVersion);               
+            Assert.Equal(0, detectedDevice.DeviceOsVersion.MinorVersion);               
+            Assert.Equal(1, detectedDevice.DeviceOsVersion.Patch);               
+        }
+
+        [Fact]
+        public void Should_Detect_Os_Version_On_Android_When_Version_9_0_0()
+        {
+            var userAgent = "Mozilla/5.0 (Linux; Android 9; BLA-L29) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36";
+            var detectedDevice = _bankIdSupportedDeviceDetector.Detect(userAgent);
+
+            Assert.Equal(BankIdSupportedDeviceOs.Android, detectedDevice.DeviceOs);
+            Assert.Equal(9, detectedDevice.DeviceOsVersion.MajorVersion);
+            Assert.Equal(0, detectedDevice.DeviceOsVersion.MinorVersion);
+            Assert.Equal(0, detectedDevice.DeviceOsVersion.Patch);
         }
     }
 }

--- a/test/ActiveLogin.Authentication.BankId.AspNetCore.Test/UserMessage/BankIdSupportedDeviceDetector_Detect_Tests.cs
+++ b/test/ActiveLogin.Authentication.BankId.AspNetCore.Test/UserMessage/BankIdSupportedDeviceDetector_Detect_Tests.cs
@@ -227,15 +227,50 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Test.UserMessage
         }
 
         [Fact]
-        public void Should_Detect_Os_Version_On_Android_When_Version_9_0_0()
+        public void Should_Detect_Os_Version_On_Android_When_Version_9()
         {
             var userAgent = "Mozilla/5.0 (Linux; Android 9; BLA-L29) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36";
             var detectedDevice = _bankIdSupportedDeviceDetector.Detect(userAgent);
 
             Assert.Equal(BankIdSupportedDeviceOs.Android, detectedDevice.DeviceOs);
             Assert.Equal(9, detectedDevice.DeviceOsVersion.MajorVersion);
-            Assert.Equal(0, detectedDevice.DeviceOsVersion.MinorVersion);
-            Assert.Equal(0, detectedDevice.DeviceOsVersion.Patch);
+            Assert.Null(detectedDevice.DeviceOsVersion.MinorVersion);
+            Assert.Null(detectedDevice.DeviceOsVersion.Patch);
+        }
+
+        [Fact]
+        public void Should_Set_Non_Parsable_Android_Minor_Version_Number_To_Null_When_Version_6_X_1()
+        {
+            var userAgent = "Mozilla/5.0 (Linux; Android 6.X.1; SM-G532G Build/MMB29T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.83 Mobile Safari/537.36";
+            var detectedDevice = _bankIdSupportedDeviceDetector.Detect(userAgent);
+
+            Assert.Equal(BankIdSupportedDeviceOs.Android, detectedDevice.DeviceOs);
+            Assert.Equal(6, detectedDevice.DeviceOsVersion.MajorVersion);
+            Assert.Null(detectedDevice.DeviceOsVersion.MinorVersion);
+            Assert.Equal(1, detectedDevice.DeviceOsVersion.Patch);
+        }
+
+        [Fact]
+        public void Should_Set_Non_Parsable_Android_Version_Numbers_To_Null()
+        {
+            var userAgent = "Mozilla/5.0 (Linux; Android 6.0.1 SM-G532G Build/MMB29T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.83 Mobile Safari/537.36";
+            var detectedDevice = _bankIdSupportedDeviceDetector.Detect(userAgent);
+
+            Assert.Null(detectedDevice.DeviceOsVersion.MajorVersion);
+            Assert.Null(detectedDevice.DeviceOsVersion.MinorVersion);
+            Assert.Null(detectedDevice.DeviceOsVersion.Patch);
+        }
+
+        [Fact]
+        public void Should_Not_Detect_Os_Version_When_Not_Android()
+        {
+            var userAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_2 like Mac OS X) AppleWebKit/603.2.4 (KHTML, like Gecko) Mobile/14F89 Safari/603.2.4 EdgiOS/41.1.35.1";
+
+            var detectedDevice = _bankIdSupportedDeviceDetector.Detect(userAgent);
+
+            Assert.Null(detectedDevice.DeviceOsVersion.MajorVersion);
+            Assert.Null(detectedDevice.DeviceOsVersion.MinorVersion);
+            Assert.Null(detectedDevice.DeviceOsVersion.Patch);
         }
     }
 }


### PR DESCRIPTION
Fixes #242.

Detect device Os version for Android and change redirect scheme for Android version >= 6 as per new guidelines.
