### PR TITLE
Fix app launch on Android

### DIFF
--- a/ActiveLogin.Authentication.sln
+++ b/ActiveLogin.Authentication.sln
@@ -82,6 +82,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ISSUE_TEMPLATE", "ISSUE_TEM
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ActiveLogin.Authentication.BankId.AspNetCore.AzureMonitor", "src\ActiveLogin.Authentication.BankId.AspNetCore.AzureMonitor\ActiveLogin.Authentication.BankId.AspNetCore.AzureMonitor.csproj", "{4CCA4973-BDCC-40B3-A09B-F8256DB2A77A}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{E5C1B133-D58E-410C-8FE0-5A897048CD0B}"
+	ProjectSection(SolutionItems) = preProject
+		docs\tests\bankid-app-launch-tests-auto-bankid.html = docs\tests\bankid-app-launch-tests-auto-bankid.html
+		docs\tests\bankid-app-launch-tests-auto-https.html = docs\tests\bankid-app-launch-tests-auto-https.html
+		docs\tests\bankid-app-launch-tests.html = docs\tests\bankid-app-launch-tests.html
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -176,6 +183,7 @@ Global
 		{84E9CCEE-4BF2-4D8D-B70B-3FB317328F29} = {A62CB923-FBEA-4F05-A776-47F8F7569DA8}
 		{0BF52185-1294-495F-93C0-853B87075863} = {84E9CCEE-4BF2-4D8D-B70B-3FB317328F29}
 		{4CCA4973-BDCC-40B3-A09B-F8256DB2A77A} = {9A0CF459-87CC-448D-B49D-EFC3D6482AA6}
+		{E5C1B133-D58E-410C-8FE0-5A897048CD0B} = {4764448D-A014-403F-A956-3F4CFFA00AF2}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2076F58C-968B-489D-94CA-B3729F5DE10D}

--- a/docs/tests/bankid-app-launch-tests-auto-bankid.html
+++ b/docs/tests/bankid-app-launch-tests-auto-bankid.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>BankID App Launch Test - Auto - bankid:///</title>
+</head>
+<body>
+    <h1>BankID App Launch Test - Auto - bankid:///</h1>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', (event) => {
+            var bankIdLaunchUrl = 'bankid:///?autostarttoken=a36fe224-f731-4d14-ad60-23b239429450&redirect=null';
+            window.location.href = bankIdLaunchUrl;
+        });
+    </script>
+</body>
+</html>

--- a/docs/tests/bankid-app-launch-tests-auto-https.html
+++ b/docs/tests/bankid-app-launch-tests-auto-https.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>BankID App Launch Test - Auto - https://app.bankid.com/</title>
+</head>
+<body>
+    <h1>BankID App Launch Test - Auto - https://app.bankid.com/</h1>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', (event) => {
+            var bankIdLaunchUrl = 'https://app.bankid.com/?autostarttoken=a36fe224-f731-4d14-ad60-23b239429450&redirect=null';
+            window.location.href = bankIdLaunchUrl;
+        });
+    </script>
+</body>
+</html>

--- a/docs/tests/bankid-app-launch-tests.html
+++ b/docs/tests/bankid-app-launch-tests.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>BankID App Launch Test</title>
+</head>
+<body>
+    <script>
+        window.openUrl = function(url) {
+            window.location.href = url;
+        };
+    </script>
+
+    <h1>BankID App Launch Test</h1>
+
+    <h2>bankid:///</h2>
+    <p>
+      <a href="bankid:///?autostarttoken=a36fe224-f731-4d14-ad60-23b239429450&redirect=null">Using a href</a>
+    </p>
+    <p>
+      <button onclick="openUrl('bankid:///?autostarttoken=a36fe224-f731-4d14-ad60-23b239429450&redirect=null')">Using window.location.href</button>
+    </p>
+    <p>
+      <a href="bankid-app-launch-tests-auto-bankid.html">Using document on load</a>
+    </p>
+
+    <hr />
+
+    <h2>https://app.bankid.com/</h2>
+    <p>
+      <a href="https://app.bankid.com/?autostarttoken=a36fe224-f731-4d14-ad60-23b239429450&redirect=null">Using a href</a>
+    </p>
+    <p>
+      <button onclick="openUrl('https://app.bankid.com/?autostarttoken=a36fe224-f731-4d14-ad60-23b239429450&redirect=null')">Using window.location.href</button>
+    </p>
+    <p>
+      <a href="bankid-app-launch-tests-auto-https.html">Using document on load</a>
+    </p>
+
+</body>
+</html>

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Models/BankIdLoginApiInitializeResponse.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Models/BankIdLoginApiInitializeResponse.cs
@@ -1,17 +1,17 @@
-﻿namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthentication.Models
+namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthentication.Models
 {
     public class BankIdLoginApiInitializeResponse
     {
         internal BankIdLoginApiInitializeResponse(
             bool isAutoLaunch,
-            bool showLaunchButton,
+            bool deviceMightRequireUserInteractionToLaunchBankIdApp,
             bool checkStatus,
             string orderRef,
             string? redirectUri,
             string? qrCodeAsBase64)
         {
             IsAutoLaunch = isAutoLaunch;
-            ShowLaunchButton = showLaunchButton;
+            DeviceMightRequireUserInteractionToLaunchBankIdApp = deviceMightRequireUserInteractionToLaunchBankIdApp;
             CheckStatus = checkStatus;
             OrderRef = orderRef;
             RedirectUri = redirectUri;
@@ -20,7 +20,7 @@
 
 
         public bool IsAutoLaunch { get; }
-        public bool ShowLaunchButton { get; }
+        public bool DeviceMightRequireUserInteractionToLaunchBankIdApp { get; }
         public bool CheckStatus { get; }
         public string OrderRef { get; }
         public string? RedirectUri { get; }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Views/BankId/_LoginScript.cshtml
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Views/BankId/_LoginScript.cshtml
@@ -115,7 +115,7 @@
                             sessionStorage.setItem(sessionStorageOrderRefKey, data.orderRef);
                         }
 
-                        if (data.showLaunchButton) {
+                        if (data.deviceMightRequireUserInteractionToLaunchBankIdApp) {
                             var startBankIdAppButtonOnClick = function(event) {
                                 window.location.href = data.redirectUri;
                                 hide(startBankIdAppButtonElement);

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Launcher/BankIdDevelopmentLauncher.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Launcher/BankIdDevelopmentLauncher.cs
@@ -13,5 +13,15 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Launcher
 
             return "#";
         }
+
+        public bool GetDeviceMightRequireUserInteractionToLaunchBankIdApp(BankIdSupportedDevice detectedDevice)
+        {
+            return false;
+        }
+
+        public bool GetDeviceWillReloadPageOnReturnFromBankIdApp(BankIdSupportedDevice detectedDevice)
+        {
+            return false;
+        }
     }
 }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Launcher/BankIdLauncher.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Launcher/BankIdLauncher.cs
@@ -19,14 +19,22 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Launcher
 
         public bool GetDeviceMightRequireUserInteractionToLaunchBankIdApp(BankIdSupportedDevice detectedDevice)
         {
-            // Some Android browsers might have issues launching a third party scheme (BankID) if there is no user interaction.
-            // Android version > 6 supports app links (https://app.bankid.com/), but still requires user interaction.
-            return detectedDevice.DeviceOs == BankIdSupportedDeviceOs.Android;
+            // On Android, some browsers will (for security reasons) not launching a
+            // third party app/scheme (BankID) if there is no user interaction.
+            //
+            // - Chrome and Samsung Internet Browser is confirmed to require User Interaction.
+            // - Firefox is confirmed to work without.
+            //
+            // HTML files to try this out is available under /docs/tests
+
+            return detectedDevice.DeviceOs == BankIdSupportedDeviceOs.Android
+                   && detectedDevice.DeviceBrowser != BankIdSupportedDeviceBrowser.Firefox;
         }
 
         public bool GetDeviceWillReloadPageOnReturnFromBankIdApp(BankIdSupportedDevice detectedDevice)
         {
             // When returned from the BankID app Safari on iOS will refresh the page/tab.
+
             return detectedDevice.DeviceOs == BankIdSupportedDeviceOs.Ios
                    && detectedDevice.DeviceBrowser == BankIdSupportedDeviceBrowser.Safari;
         }
@@ -49,7 +57,8 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Launcher
         private static bool CanUseAppLink(BankIdSupportedDevice device)
         {
             // Only Safari on IOS and Chrome on Android version >= 6 seems to support
-            //  the https://app.bankid.com/ reference
+            //  the https://app.bankid.com/ launch url
+
             return IsSafariOnIos(device) || IsChromeOnAndroid6OrGreater(device);
         }
 

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Launcher/IBankIdLauncher.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Launcher/IBankIdLauncher.cs
@@ -1,9 +1,11 @@
-﻿using ActiveLogin.Authentication.BankId.AspNetCore.SupportedDevice;
+using ActiveLogin.Authentication.BankId.AspNetCore.SupportedDevice;
 
 namespace ActiveLogin.Authentication.BankId.AspNetCore.Launcher
 {
     public interface IBankIdLauncher
     {
         string GetLaunchUrl(BankIdSupportedDevice device, LaunchUrlRequest request);
+        bool GetDeviceMightRequireUserInteractionToLaunchBankIdApp(BankIdSupportedDevice detectedDevice);
+        bool GetDeviceWillReloadPageOnReturnFromBankIdApp(BankIdSupportedDevice detectedDevice);
     }
 }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Launcher/IBankIdLauncher.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Launcher/IBankIdLauncher.cs
@@ -4,8 +4,26 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Launcher
 {
     public interface IBankIdLauncher
     {
+        /// <summary>
+        /// Returns the url used to launch the BankID app.
+        /// </summary>
+        /// <param name="device">The device that the user is using.</param>
+        /// <param name="request">Launch info</param>
+        /// <returns></returns>
         string GetLaunchUrl(BankIdSupportedDevice device, LaunchUrlRequest request);
+
+        /// <summary>
+        /// If the device/browser might require user interaction, such as button click, to launch a third party app.
+        /// </summary>
+        /// <param name="detectedDevice"></param>
+        /// <returns></returns>
         bool GetDeviceMightRequireUserInteractionToLaunchBankIdApp(BankIdSupportedDevice detectedDevice);
+
+        /// <summary>
+        /// If the device/browser will reload the page on return from the BankID app.
+        /// </summary>
+        /// <param name="detectedDevice"></param>
+        /// <returns></returns>
         bool GetDeviceWillReloadPageOnReturnFromBankIdApp(BankIdSupportedDevice detectedDevice);
     }
 }

--- a/test/ActiveLogin.Authentication.BankId.AspNetCore.Test/Helpers/TestBankIdLauncher.cs
+++ b/test/ActiveLogin.Authentication.BankId.AspNetCore.Test/Helpers/TestBankIdLauncher.cs
@@ -9,5 +9,15 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Test.Helpers
         {
             return request.RedirectUrl;
         }
+
+        public bool GetDeviceMightRequireUserInteractionToLaunchBankIdApp(BankIdSupportedDevice detectedDevice)
+        {
+            return false;
+        }
+
+        public bool GetDeviceWillReloadPageOnReturnFromBankIdApp(BankIdSupportedDevice detectedDevice)
+        {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
This PR fixes #251 and fixes #252.

High level overview of this PR:

- [x] Extract decisions into the `IBankIdLauncher` interface
- [x] Ensure using app link only on browsers that supports it
- [x] Show button on Android