### PR TITLE
Add support for Samsung Internet Browser and Opera on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,11 +384,17 @@ A more technical deep dive of the cookies can be found in [this issue](https://g
 
 We aim at supporting the latest version of all major browsers (Edge, Chrome, Firefox, Safari) both on desktop and on mobile.
 
-All browsers on mobile are supported, but the full automated flow on same device (redirect between apps) are supported on these:
-- Safari on iOS
-- Chrome on iOS
-- Firefox on iOS
-- All browsers on Android
+All browsers on mobile are supported, but the redirect flow are tested on these:
+- iOS
+    - Safari
+    - Chrome
+    - Firefox
+- Android
+    - Chrome
+    - Firefox
+    - Samsung Internet Browser
+    - Opera
+    - Edge
 
 If you aim to support IE11 a polyfill for some JavaScript features we are using is needed.
 

--- a/src/ActiveLogin.Authentication.BankId.Api/ActiveLogin.Authentication.BankId.Api.csproj
+++ b/src/ActiveLogin.Authentication.BankId.Api/ActiveLogin.Authentication.BankId.Api.csproj
@@ -12,7 +12,7 @@
         <PackageId>ActiveLogin.Authentication.BankId.Api</PackageId>
 
         <VersionPrefix>4.0.0</VersionPrefix>
-        <VersionSuffix>beta-1</VersionSuffix>
+        <VersionSuffix>beta-2</VersionSuffix>
         <AssemblyVersion>4.0.0.0</AssemblyVersion>
         <FileVersion Condition="'$(BUILD_BUILDNUMBER)' == ''">$(VersionPrefix).0</FileVersion>
         <FileVersion Condition="'$(BUILD_BUILDNUMBER)' != ''">$(VersionPrefix).$(BUILD_BUILDNUMBER)</FileVersion>

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore.Azure/ActiveLogin.Authentication.BankId.AspNetCore.Azure.csproj
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore.Azure/ActiveLogin.Authentication.BankId.AspNetCore.Azure.csproj
@@ -12,7 +12,7 @@
         <PackageId>ActiveLogin.Authentication.BankId.AspNetCore.Azure</PackageId>
 
         <VersionPrefix>4.0.0</VersionPrefix>
-        <VersionSuffix>beta-1</VersionSuffix>
+        <VersionSuffix>beta-2</VersionSuffix>
         <AssemblyVersion>4.0.0.0</AssemblyVersion>
         <FileVersion Condition="'$(BUILD_BUILDNUMBER)' == ''">$(VersionPrefix).0</FileVersion>
         <FileVersion Condition="'$(BUILD_BUILDNUMBER)' != ''">$(VersionPrefix).$(BUILD_BUILDNUMBER)</FileVersion>

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore.AzureMonitor/ActiveLogin.Authentication.BankId.AspNetCore.AzureMonitor.csproj
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore.AzureMonitor/ActiveLogin.Authentication.BankId.AspNetCore.AzureMonitor.csproj
@@ -12,7 +12,7 @@
         <PackageId>ActiveLogin.Authentication.BankId.AspNetCore.AzureMonitor</PackageId>
 
         <VersionPrefix>4.0.0</VersionPrefix>
-        <VersionSuffix>beta-1</VersionSuffix>
+        <VersionSuffix>beta-2</VersionSuffix>
         <AssemblyVersion>4.0.0.0</AssemblyVersion>
         <FileVersion Condition="'$(BUILD_BUILDNUMBER)' == ''">$(VersionPrefix).0</FileVersion>
         <FileVersion Condition="'$(BUILD_BUILDNUMBER)' != ''">$(VersionPrefix).$(BUILD_BUILDNUMBER)</FileVersion>

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore.QRCoder/ActiveLogin.Authentication.BankId.AspNetCore.QRCoder.csproj
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore.QRCoder/ActiveLogin.Authentication.BankId.AspNetCore.QRCoder.csproj
@@ -13,7 +13,7 @@
         <RootNamespace>ActiveLogin.Authentication.BankId.AspNetCore.QrCoder</RootNamespace>
 
         <VersionPrefix>4.0.0</VersionPrefix>
-        <VersionSuffix>beta-1</VersionSuffix>
+        <VersionSuffix>beta-2</VersionSuffix>
         <AssemblyVersion>4.0.0.0</AssemblyVersion>
         <FileVersion Condition="'$(BUILD_BUILDNUMBER)' == ''">$(VersionPrefix).0</FileVersion>
         <FileVersion Condition="'$(BUILD_BUILDNUMBER)' != ''">$(VersionPrefix).$(BUILD_BUILDNUMBER)</FileVersion>

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/ActiveLogin.Authentication.BankId.AspNetCore.csproj
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/ActiveLogin.Authentication.BankId.AspNetCore.csproj
@@ -14,7 +14,7 @@
         <PackageId>ActiveLogin.Authentication.BankId.AspNetCore</PackageId>
 
         <VersionPrefix>4.0.0</VersionPrefix>
-        <VersionSuffix>beta-1</VersionSuffix>
+        <VersionSuffix>beta-2</VersionSuffix>
         <AssemblyVersion>4.0.0.0</AssemblyVersion>
         <FileVersion Condition="'$(BUILD_BUILDNUMBER)' == ''">$(VersionPrefix).0</FileVersion>
         <FileVersion Condition="'$(BUILD_BUILDNUMBER)' != ''">$(VersionPrefix).$(BUILD_BUILDNUMBER)</FileVersion>

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Events/BankIdAuthErrorEvent.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Events/BankIdAuthErrorEvent.cs
@@ -1,5 +1,6 @@
 using ActiveLogin.Authentication.BankId.Api;
 using ActiveLogin.Authentication.BankId.AspNetCore.Events.Infrastructure;
+using ActiveLogin.Authentication.BankId.AspNetCore.SupportedDevice;
 using ActiveLogin.Identity.Swedish;
 
 namespace ActiveLogin.Authentication.BankId.AspNetCore.Events
@@ -9,15 +10,18 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Events
     /// </summary>
     public class BankIdAuthErrorEvent : BankIdEvent
     {
-        internal BankIdAuthErrorEvent(SwedishPersonalIdentityNumber? personalIdentityNumber, BankIdApiException bankIdApiException)
+        internal BankIdAuthErrorEvent(SwedishPersonalIdentityNumber? personalIdentityNumber, BankIdApiException bankIdApiException, BankIdSupportedDevice detectedUserDevice)
             : base(BankIdEventTypes.AuthErrorEventId, BankIdEventTypes.AuthErrorEventName, BankIdEventSeverity.Error)
         {
             PersonalIdentityNumber = personalIdentityNumber;
             BankIdApiException = bankIdApiException;
+            DetectedUserDevice = detectedUserDevice;
         }
 
         public SwedishPersonalIdentityNumber? PersonalIdentityNumber { get; }
 
         public BankIdApiException BankIdApiException { get; }
+
+        public BankIdSupportedDevice DetectedUserDevice { get; }
     }
 }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Events/BankIdAuthSuccessEvent.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Events/BankIdAuthSuccessEvent.cs
@@ -1,4 +1,5 @@
 using ActiveLogin.Authentication.BankId.AspNetCore.Events.Infrastructure;
+using ActiveLogin.Authentication.BankId.AspNetCore.SupportedDevice;
 using ActiveLogin.Identity.Swedish;
 
 namespace ActiveLogin.Authentication.BankId.AspNetCore.Events
@@ -8,16 +9,19 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Events
     /// </summary>
     public class BankIdAuthSuccessEvent : BankIdEvent
     {
-        internal BankIdAuthSuccessEvent(SwedishPersonalIdentityNumber? personalIdentityNumber, string orderRef)
+        internal BankIdAuthSuccessEvent(SwedishPersonalIdentityNumber? personalIdentityNumber, string orderRef, BankIdSupportedDevice detectedUserDevice)
             : base(BankIdEventTypes.AuthSuccessId, BankIdEventTypes.AuthSuccessName, BankIdEventSeverity.Success)
         {
             PersonalIdentityNumber = personalIdentityNumber;
             OrderRef = orderRef;
+            DetectedUserDevice = detectedUserDevice;
         }
 
         public SwedishPersonalIdentityNumber? PersonalIdentityNumber { get; }
 
         public string OrderRef { get; }
+
+        public BankIdSupportedDevice DetectedUserDevice { get; }
     }
 }
 

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Events/Infrastructure/BankIdEventTrigger.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Events/Infrastructure/BankIdEventTrigger.cs
@@ -9,13 +9,14 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Events.Infrastructure
 {
     internal class BankIdEventTrigger : IBankIdEventTrigger
     {
-        private readonly BankIdActiveLoginContext _bankIdActiveLoginContext;
         private readonly List<IBankIdEventListener> _listeners;
+        private readonly BankIdActiveLoginContext _bankIdActiveLoginContext;
+        
 
         public BankIdEventTrigger(IEnumerable<IBankIdEventListener> listeners, IOptions<BankIdActiveLoginContext> bankIdActiveLoginContext)
         {
-            _bankIdActiveLoginContext = bankIdActiveLoginContext.Value;
             _listeners = listeners.ToList();
+            _bankIdActiveLoginContext = bankIdActiveLoginContext.Value;
         }
 
         public async Task TriggerAsync(BankIdEvent bankIdEvent)

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Launcher/BankIdDevelopmentLauncher.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Launcher/BankIdDevelopmentLauncher.cs
@@ -1,27 +1,13 @@
-using ActiveLogin.Authentication.BankId.AspNetCore.SupportedDevice;
+using Microsoft.AspNetCore.Http;
 
 namespace ActiveLogin.Authentication.BankId.AspNetCore.Launcher
 {
     internal class BankIdDevelopmentLauncher : IBankIdLauncher
     {
-        public string GetLaunchUrl(BankIdSupportedDevice device, LaunchUrlRequest request)
+        public BankIdLaunchInfo GetLaunchInfo(LaunchUrlRequest request, HttpContext httpContext)
         {
-            if (device.DeviceOs == BankIdSupportedDeviceOs.Ios)
-            {
-                return request.RedirectUrl;
-            }
-
-            return "#";
-        }
-
-        public bool GetDeviceMightRequireUserInteractionToLaunchBankIdApp(BankIdSupportedDevice detectedDevice)
-        {
-            return false;
-        }
-
-        public bool GetDeviceWillReloadPageOnReturnFromBankIdApp(BankIdSupportedDevice detectedDevice)
-        {
-            return false;
+            // Always redirect back without user interaction in simulated mode
+            return new BankIdLaunchInfo(request.RedirectUrl, false, false);
         }
     }
 }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Launcher/BankIdLaunchInfo.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Launcher/BankIdLaunchInfo.cs
@@ -1,0 +1,29 @@
+namespace ActiveLogin.Authentication.BankId.AspNetCore.Launcher
+{
+    public class BankIdLaunchInfo
+    {
+        public BankIdLaunchInfo(string launchUrl, bool deviceMightRequireUserInteractionToLaunchBankIdApp, bool deviceWillReloadPageOnReturnFromBankIdApp)
+        {
+            LaunchUrl = launchUrl;
+            DeviceMightRequireUserInteractionToLaunchBankIdApp = deviceMightRequireUserInteractionToLaunchBankIdApp;
+            DeviceWillReloadPageOnReturnFromBankIdApp = deviceWillReloadPageOnReturnFromBankIdApp;
+        }
+
+        /// <summary>
+        /// Returns the url used to launch the BankID app.
+        /// </summary>
+        public string LaunchUrl { get; }
+
+        /// <summary>
+        /// If the device/browser might require user interaction, such as button click, to launch a third party app.
+        /// </summary>
+        /// <returns></returns>
+        public bool DeviceMightRequireUserInteractionToLaunchBankIdApp { get; }
+
+        /// <summary>
+        /// If the device/browser will reload the page on return from the BankID app.
+        /// </summary>
+        /// <returns></returns>
+        public bool DeviceWillReloadPageOnReturnFromBankIdApp { get; }
+    }
+}

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Launcher/IBankIdLauncher.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Launcher/IBankIdLauncher.cs
@@ -1,29 +1,15 @@
-using ActiveLogin.Authentication.BankId.AspNetCore.SupportedDevice;
+using Microsoft.AspNetCore.Http;
 
 namespace ActiveLogin.Authentication.BankId.AspNetCore.Launcher
 {
     public interface IBankIdLauncher
     {
         /// <summary>
-        /// Returns the url used to launch the BankID app.
+        /// Get info on how to launch the BankID app given the current HttpContext. Use (for example) User Agent to detect device.
         /// </summary>
-        /// <param name="device">The device that the user is using.</param>
         /// <param name="request">Launch info</param>
+        /// <param name="httpContext">HttpContext to extract info from.</param>
         /// <returns></returns>
-        string GetLaunchUrl(BankIdSupportedDevice device, LaunchUrlRequest request);
-
-        /// <summary>
-        /// If the device/browser might require user interaction, such as button click, to launch a third party app.
-        /// </summary>
-        /// <param name="detectedDevice"></param>
-        /// <returns></returns>
-        bool GetDeviceMightRequireUserInteractionToLaunchBankIdApp(BankIdSupportedDevice detectedDevice);
-
-        /// <summary>
-        /// If the device/browser will reload the page on return from the BankID app.
-        /// </summary>
-        /// <param name="detectedDevice"></param>
-        /// <returns></returns>
-        bool GetDeviceWillReloadPageOnReturnFromBankIdApp(BankIdSupportedDevice detectedDevice);
+        BankIdLaunchInfo GetLaunchInfo(LaunchUrlRequest request, HttpContext httpContext);
     }
 }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/SupportedDevice/BankIdSupportedDevice.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/SupportedDevice/BankIdSupportedDevice.cs
@@ -2,8 +2,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.SupportedDevice
 {
     public class BankIdSupportedDevice
     {
-        public BankIdSupportedDevice(BankIdSupportedDeviceType deviceType, BankIdSupportedDeviceOs deviceOs,
-            BankIdSupportedDeviceBrowser deviceBrowser, BankIdSupportedDeviceOsVersion deviceOsVersion)
+        public BankIdSupportedDevice(BankIdSupportedDeviceType deviceType, BankIdSupportedDeviceOs deviceOs, BankIdSupportedDeviceBrowser deviceBrowser, BankIdSupportedDeviceOsVersion deviceOsVersion)
         {
             DeviceType = deviceType;
             DeviceOs = deviceOs;

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/SupportedDevice/BankIdSupportedDeviceBrowser.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/SupportedDevice/BankIdSupportedDeviceBrowser.cs
@@ -7,6 +7,8 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.SupportedDevice
         Chrome,
         Safari,
         Firefox,
-        Edge
+        Edge,
+        SamsungBrowser,
+        Opera
     }
 }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/SupportedDevice/BankIdSupportedDeviceOsVersion.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/SupportedDevice/BankIdSupportedDeviceOsVersion.cs
@@ -2,15 +2,36 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.SupportedDevice
 {
     public class BankIdSupportedDeviceOsVersion
     {
-        public BankIdSupportedDeviceOsVersion(int? majorVersion = null, int? minorVersion = null, int? patch = null)
+        public BankIdSupportedDeviceOsVersion(int majorVersion)
         {
             MajorVersion = majorVersion;
+        }
+
+        public BankIdSupportedDeviceOsVersion(int majorVersion, int minorVersion)
+            : this(majorVersion)
+        {
             MinorVersion = minorVersion;
+        }
+
+        public BankIdSupportedDeviceOsVersion(int majorVersion, int minorVersion, int patch)
+            : this(majorVersion, minorVersion)
+        {
             Patch = patch;
         }
 
+        private BankIdSupportedDeviceOsVersion()
+        {
+        }
+
+        public static BankIdSupportedDeviceOsVersion Empty = new BankIdSupportedDeviceOsVersion();
+
         public int? MajorVersion { get; }
         public int? MinorVersion { get; }
-        public int? Patch { get;}
+        public int? Patch { get; }
+
+        public override string ToString()
+        {
+            return $"{MajorVersion}.{MinorVersion}.{Patch}".TrimEnd('.');
+        }
     }
 }

--- a/test/ActiveLogin.Authentication.BankId.AspNetCore.Test/Helpers/TestBankIdLauncher.cs
+++ b/test/ActiveLogin.Authentication.BankId.AspNetCore.Test/Helpers/TestBankIdLauncher.cs
@@ -1,23 +1,14 @@
 using ActiveLogin.Authentication.BankId.AspNetCore.Launcher;
-using ActiveLogin.Authentication.BankId.AspNetCore.SupportedDevice;
+using Microsoft.AspNetCore.Http;
 
 namespace ActiveLogin.Authentication.BankId.AspNetCore.Test.Helpers
 {
     internal class TestBankIdLauncher : IBankIdLauncher
     {
-        public string GetLaunchUrl(BankIdSupportedDevice device, LaunchUrlRequest request)
+        public BankIdLaunchInfo GetLaunchInfo(LaunchUrlRequest request, HttpContext httpContext)
         {
-            return request.RedirectUrl;
-        }
-
-        public bool GetDeviceMightRequireUserInteractionToLaunchBankIdApp(BankIdSupportedDevice detectedDevice)
-        {
-            return false;
-        }
-
-        public bool GetDeviceWillReloadPageOnReturnFromBankIdApp(BankIdSupportedDevice detectedDevice)
-        {
-            return false;
+            // Always redirect back without user interaction in simulated mode
+            return new BankIdLaunchInfo(request.RedirectUrl, false, false);
         }
     }
 }

--- a/test/ActiveLogin.Authentication.BankId.AspNetCore.Test/UserMessage/BankIdSupportedDeviceDetector_Detect_Tests.cs
+++ b/test/ActiveLogin.Authentication.BankId.AspNetCore.Test/UserMessage/BankIdSupportedDeviceDetector_Detect_Tests.cs
@@ -204,6 +204,28 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Test.UserMessage
         }
 
         [Fact]
+        public void Should_Detect_SamsungBrowser_On_Android()
+        {
+            var userAgent = "Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-G960U) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36";
+            var detectedDevice = _bankIdSupportedDeviceDetector.Detect(userAgent);
+
+            Assert.Equal(BankIdSupportedDeviceType.Mobile, detectedDevice.DeviceType);
+            Assert.Equal(BankIdSupportedDeviceOs.Android, detectedDevice.DeviceOs);
+            Assert.Equal(BankIdSupportedDeviceBrowser.SamsungBrowser, detectedDevice.DeviceBrowser);
+        }
+
+        [Fact]
+        public void Should_Detect_Opera_On_Android()
+        {
+            var userAgent = "Mozilla/5.0 (Linux; Android 10; SM-G970F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36 OPR/55.2.2719";
+            var detectedDevice = _bankIdSupportedDeviceDetector.Detect(userAgent);
+
+            Assert.Equal(BankIdSupportedDeviceType.Mobile, detectedDevice.DeviceType);
+            Assert.Equal(BankIdSupportedDeviceOs.Android, detectedDevice.DeviceOs);
+            Assert.Equal(BankIdSupportedDeviceBrowser.Opera, detectedDevice.DeviceBrowser);
+        }
+
+        [Fact]
         public void Should_Detect_Edge_On_Android()
         {
             var userAgent = "Mozilla/5.0 (Linux; Android 8.0; Pixel XL Build/OPP3.170518.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.0 Mobile Safari/537.36 EdgA/41.1.35.1";
@@ -246,7 +268,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Test.UserMessage
 
             Assert.Equal(BankIdSupportedDeviceOs.Android, detectedDevice.DeviceOs);
             Assert.Equal(6, detectedDevice.DeviceOsVersion.MajorVersion);
-            Assert.Null(detectedDevice.DeviceOsVersion.MinorVersion);
+            Assert.Equal(0, detectedDevice.DeviceOsVersion.MinorVersion);
             Assert.Equal(1, detectedDevice.DeviceOsVersion.Patch);
         }
 


### PR DESCRIPTION
This PR is related to #242, #251, #252

High level overview of this PR:

- [x] Add support for Samsung Internet Browser and Opera on Android
- [x] Add device info to logging
- [x] Refactor launcher implementation