### PR TITLE
Fix failing debug logger

### DIFF
--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Events/BankIdAspNetAuthenticateSuccessEvent.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Events/BankIdAspNetAuthenticateSuccessEvent.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using ActiveLogin.Authentication.BankId.AspNetCore.Events.Infrastructure;
 using ActiveLogin.Identity.Swedish;
 using Microsoft.AspNetCore.Authentication;
@@ -16,6 +17,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Events
             PersonalIdentityNumber = personalIdentityNumber;
         }
 
+        [JsonIgnore] // ClaimsPrincipal have self circular references
         public AuthenticationTicket AuthenticationTicket { get; }
         public SwedishPersonalIdentityNumber PersonalIdentityNumber { get; }
     }

--- a/test/ActiveLogin.Authentication.BankId.AspNetCore.Test/Events/Infrastructure/BankIdDebugEventListener_Tests.cs
+++ b/test/ActiveLogin.Authentication.BankId.AspNetCore.Test/Events/Infrastructure/BankIdDebugEventListener_Tests.cs
@@ -33,5 +33,31 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Test.Events.Infrastructur
             Assert.Contains("\"eventTypeName\": \"TestEvent\"", json);
             Assert.Contains("\"eventSeverity\": \"Information\"", json);
         }
+
+        [Fact]
+        public async Task Serializes_Event_With_Depth_Larger_Than_0()
+        {
+            // Arrange
+            var logger = new Mock<ILogger<BankIdDebugEventListener>>();
+            var debugEventListener = new BankIdDebugEventListener(logger.Object);
+            var testEvent = new TestBankIdEvent(2000, "TestEvent", BankIdEventSeverity.Success);
+            var deepEvent = new TestDeepBankIdEvent(1000, "DeepEvent", BankIdEventSeverity.Information, testEvent);
+
+            // Act
+
+            await debugEventListener.HandleAsync(deepEvent);
+
+            // Assert
+            var invocation = logger.Invocations[0];
+
+            var eventId = (EventId)invocation.Arguments[1];
+            Assert.Equal("DeepEvent", eventId.Name);
+            Assert.Equal(1000, eventId.Id);
+
+            var json = invocation.Arguments[2].ToString();
+            Assert.Contains("\"eventTypeId\": 2000", json);
+            Assert.Contains("\"eventTypeName\": \"TestEvent\"", json);
+            Assert.Contains("\"eventSeverity\": \"Success\"", json);
+        }
     }
 }

--- a/test/ActiveLogin.Authentication.BankId.AspNetCore.Test/Helpers/TestDeepBankIdEvent.cs
+++ b/test/ActiveLogin.Authentication.BankId.AspNetCore.Test/Helpers/TestDeepBankIdEvent.cs
@@ -1,0 +1,14 @@
+using ActiveLogin.Authentication.BankId.AspNetCore.Events.Infrastructure;
+
+namespace ActiveLogin.Authentication.BankId.AspNetCore.Test.Helpers
+{
+    public class TestDeepBankIdEvent : BankIdEvent
+    {
+        internal TestDeepBankIdEvent(int eventTypeId, string eventTypeName, BankIdEventSeverity eventSeverity, TestBankIdEvent testEvent) : base(eventTypeId, eventTypeName, eventSeverity)
+        {
+            TestEvent = testEvent;
+        }
+
+        public TestBankIdEvent TestEvent { get; set; }
+    }
+}


### PR DESCRIPTION
This PR fixes #260.

High level overview of this PR:

- [x] Ignore known property with circular dependency
- [x] Format Personal identity numbers when seralizing
- [x] Catch any exceptions on debug logging