### PR TITLE
Add BankId prefix to end user ip resolver

### DIFF
--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Controllers/BankIdApiController.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Controllers/BankIdApiController.cs
@@ -39,7 +39,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthenticatio
         private readonly IBankIdLoginOptionsProtector _loginOptionsProtector;
         private readonly IBankIdLoginResultProtector _loginResultProtector;
         private readonly IBankIdQrCodeGenerator _qrCodeGenerator;
-        private readonly IEndUserIpResolver _endUserIpResolver;
+        private readonly IBankIdEndUserIpResolver _bankIdEndUserIpResolver;
         private readonly IBankIdEventTrigger _bankIdEventTrigger;
 
         public BankIdApiController(
@@ -53,7 +53,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthenticatio
             IBankIdLoginOptionsProtector loginOptionsProtector,
             IBankIdLoginResultProtector loginResultProtector,
             IBankIdQrCodeGenerator qrCodeGenerator,
-            IEndUserIpResolver endUserIpResolver,
+            IBankIdEndUserIpResolver bankIdEndUserIpResolver,
             IBankIdEventTrigger bankIdEventTrigger)
         {
             _urlEncoder = urlEncoder;
@@ -66,7 +66,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthenticatio
             _loginOptionsProtector = loginOptionsProtector;
             _loginResultProtector = loginResultProtector;
             _qrCodeGenerator = qrCodeGenerator;
-            _endUserIpResolver = endUserIpResolver;
+            _bankIdEndUserIpResolver = bankIdEndUserIpResolver;
             _bankIdEventTrigger = bankIdEventTrigger;
         }
 
@@ -151,7 +151,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthenticatio
         
         private AuthRequest GetAuthRequest(SwedishPersonalIdentityNumber? personalIdentityNumber, BankIdLoginOptions loginOptions)
         {
-            var endUserIp = _endUserIpResolver.GetEndUserIp(HttpContext);
+            var endUserIp = _bankIdEndUserIpResolver.GetEndUserIp(HttpContext);
             var personalIdentityNumberString = personalIdentityNumber?.To12DigitString();
             var autoStartTokenRequired = string.IsNullOrEmpty(personalIdentityNumberString) ? true : (bool?)null;
 

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdBuilderExtensions.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdBuilderExtensions.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             services.TryAddTransient<IBankIdEventTrigger, BankIdEventTrigger>();
 
-            builder.UseEndUserIpResolver<RemoteIpAddressEndUserIpResolver>();
+            builder.UseEndUserIpResolver<BankIdRemoteIpAddressEndUserIpResolver>();
 
             builder.AddEventListener<BankIdLoggerEventListener>();
             builder.AddEventListener<BankIdResultStoreEventListener>();
@@ -121,9 +121,9 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <typeparam name="TEndUserIpResolverImplementation"></typeparam>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public static IBankIdBuilder UseEndUserIpResolver<TEndUserIpResolverImplementation>(this IBankIdBuilder builder) where TEndUserIpResolverImplementation : class, IEndUserIpResolver
+        public static IBankIdBuilder UseEndUserIpResolver<TEndUserIpResolverImplementation>(this IBankIdBuilder builder) where TEndUserIpResolverImplementation : class, IBankIdEndUserIpResolver
         {
-            builder.AuthenticationBuilder.Services.AddTransient<IEndUserIpResolver, TEndUserIpResolverImplementation>();
+            builder.AuthenticationBuilder.Services.AddTransient<IBankIdEndUserIpResolver, TEndUserIpResolverImplementation>();
 
             return builder;
         }
@@ -136,7 +136,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns></returns>
         public static IBankIdBuilder UseEndUserIpResolver(this IBankIdBuilder builder, Func<HttpContext, string> resolver)
         {
-            builder.AuthenticationBuilder.Services.AddTransient<IEndUserIpResolver>(x => new DynamicEndUserIpResolver(resolver));
+            builder.AuthenticationBuilder.Services.AddTransient<IBankIdEndUserIpResolver>(x => new BankIdDynamicEndUserIpResolver(resolver));
 
             return builder;
         }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/EndUserContext/BankIdDynamicEndUserIpResolver.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/EndUserContext/BankIdDynamicEndUserIpResolver.cs
@@ -3,11 +3,11 @@ using Microsoft.AspNetCore.Http;
 
 namespace ActiveLogin.Authentication.BankId.AspNetCore.EndUserContext
 {
-    internal class DynamicEndUserIpResolver : IEndUserIpResolver
+    internal class BankIdDynamicEndUserIpResolver : IBankIdEndUserIpResolver
     {
         private readonly Func<HttpContext, string> _resolver;
 
-        public DynamicEndUserIpResolver(Func<HttpContext, string> resolver)
+        public BankIdDynamicEndUserIpResolver(Func<HttpContext, string> resolver)
         {
             _resolver = resolver;
         }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/EndUserContext/BankIdRemoteIpAddressEndUserIpResolver.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/EndUserContext/BankIdRemoteIpAddressEndUserIpResolver.cs
@@ -5,7 +5,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.EndUserContext
     /// <summary>
     /// Resolves the end user ip of the user from RemoteIpAddress of the connection.
     /// </summary>
-    public class RemoteIpAddressEndUserIpResolver : IEndUserIpResolver
+    public class BankIdRemoteIpAddressEndUserIpResolver : IBankIdEndUserIpResolver
     {
         public string GetEndUserIp(HttpContext httpContext)
         {

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/EndUserContext/IBankIdEndUserIpResolver.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/EndUserContext/IBankIdEndUserIpResolver.cs
@@ -5,7 +5,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.EndUserContext
     /// <summary>
     /// Resolves end user ip for the user.
     /// </summary>
-    public interface IEndUserIpResolver
+    public interface IBankIdEndUserIpResolver
     {
         /// <summary>
         /// Return the end user IP for the user.


### PR DESCRIPTION
High level overview of this PR:

- [x] Rename EndUsderIPResolver to be prefixed with BankId, this harmonmizes with all other classes and interfaces