### PR TITLE
Made model constructors public to enable deserialization

### DIFF
--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Models/BankIdLoginApiCancelRequest.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Models/BankIdLoginApiCancelRequest.cs
@@ -4,7 +4,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthenticatio
 {
     public class BankIdLoginApiCancelRequest
     {
-        internal BankIdLoginApiCancelRequest()
+        public BankIdLoginApiCancelRequest()
         {
 
         }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Models/BankIdLoginApiInitializeRequest.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Models/BankIdLoginApiInitializeRequest.cs
@@ -1,10 +1,10 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 
 namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthentication.Models
 {
     public class BankIdLoginApiInitializeRequest
     {
-        internal BankIdLoginApiInitializeRequest()
+        public BankIdLoginApiInitializeRequest()
         {
 
         }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Models/BankIdLoginApiStatusRequest.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Models/BankIdLoginApiStatusRequest.cs
@@ -1,10 +1,10 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 
 namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthentication.Models
 {
     public class BankIdLoginApiStatusRequest
     {
-        internal BankIdLoginApiStatusRequest()
+        public BankIdLoginApiStatusRequest()
         {
 
         }


### PR DESCRIPTION
High level overview of this PR:
In .NET 5, it seems as though the JSON deserialization currently requires public constructors for it to work. Because of this, I have updated the constructors for the request models to make sure it works.

- [x] Updated request models to have public constructors