### PR TITLE
Add response for animated Qr tokens

### DIFF
--- a/src/ActiveLogin.Authentication.BankId.Api/BankIdHttpClientExtensions.cs
+++ b/src/ActiveLogin.Authentication.BankId.Api/BankIdHttpClientExtensions.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using ActiveLogin.Authentication.BankId.Api.Errors;
+using ActiveLogin.Authentication.BankId.Api.Models;
 using ActiveLogin.Authentication.Common.Serialization;
 
 namespace ActiveLogin.Authentication.BankId.Api
@@ -14,6 +15,12 @@ namespace ActiveLogin.Authentication.BankId.Api
         public static async Task<TResult> PostAsync<TRequest, TResult>(this HttpClient httpClient, string url, TRequest request)
         {
             var requestJson = SystemRuntimeJsonSerializer.Serialize(request);
+            if (httpClient.BaseAddress.AbsolutePath?.EndsWith("v5", StringComparison.InvariantCultureIgnoreCase) == true
+                && requestJson.Contains("\"tokenStartRequired\""))
+            {
+                // Simple solution for fallback compatibility with v5
+                requestJson = requestJson.Replace("\"tokenStartRequired\"", "\"autoStartTokenRequired\"");
+            }
             var requestContent = GetJsonStringContent(requestJson);
 
             HttpResponseMessage httpResponseMessage;

--- a/src/ActiveLogin.Authentication.BankId.Api/BankIdSimulatedApiClient.cs
+++ b/src/ActiveLogin.Authentication.BankId.Api/BankIdSimulatedApiClient.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -87,7 +87,7 @@ namespace ActiveLogin.Authentication.BankId.Api
             }
 
             var response = await GetOrderResponseAsync(request.PersonalIdentityNumber, request.EndUserIp).ConfigureAwait(false);
-            return new AuthResponse(response.OrderRef, response.AutoStartToken);
+            return new AuthResponse(response.OrderRef, response.AutoStartToken, response.QrStartSecret, response.QrStartSecret);
         }
 
         public async Task<SignResponse> SignAsync(SignRequest request)
@@ -98,7 +98,7 @@ namespace ActiveLogin.Authentication.BankId.Api
             }
 
             var response = await GetOrderResponseAsync(request.PersonalIdentityNumber, request.EndUserIp).ConfigureAwait(false);
-            return new SignResponse(response.OrderRef, response.AutoStartToken);
+            return new SignResponse(response.OrderRef, response.AutoStartToken, response.QrStartToken, response.QrStartSecret);
         }
 
         private async Task<OrderResponse> GetOrderResponseAsync(string? personalIdentityNumber, string endUserIp)
@@ -117,8 +117,10 @@ namespace ActiveLogin.Authentication.BankId.Api
             _auths.Add(orderRef, auth);
 
             var autoStartToken = Guid.NewGuid().ToString().Replace("-", string.Empty);
+            var qrStartToken = Guid.NewGuid().ToString().Replace("-", string.Empty);
+            var qrStartSecret = Guid.NewGuid().ToString().Replace("-", string.Empty);
 
-            return new OrderResponse(orderRef, autoStartToken);
+            return new OrderResponse(orderRef, autoStartToken, qrStartToken, qrStartSecret);
         }
 
         private async Task EnsureNoExistingAuth(string personalIdentityNumber)
@@ -242,15 +244,21 @@ namespace ActiveLogin.Authentication.BankId.Api
 
         private class OrderResponse
         {
-            public OrderResponse(string orderRef, string autoStartToken)
+            public OrderResponse(string orderRef, string autoStartToken, string qrStartToken, string qrStartSecret)
             {
                 OrderRef = orderRef;
                 AutoStartToken = autoStartToken;
+                QrStartToken = qrStartToken;
+                QrStartSecret = qrStartSecret;
             }
 
             public string OrderRef { get; set; }
 
             public string AutoStartToken { get; set; }
+
+            public string QrStartToken { get; set; }
+
+            public string QrStartSecret { get; set; }
         }
 
         public class CollectState

--- a/src/ActiveLogin.Authentication.BankId.Api/Models/AuthResponse.cs
+++ b/src/ActiveLogin.Authentication.BankId.Api/Models/AuthResponse.cs
@@ -8,10 +8,12 @@ namespace ActiveLogin.Authentication.BankId.Api.Models
     [DataContract]
     public class AuthResponse
     {
-        public AuthResponse(string orderRef, string autoStartToken)
+        public AuthResponse(string orderRef, string autoStartToken, string qrStartToken, string qrStartSecret)
         {
             OrderRef = orderRef;
             AutoStartToken = autoStartToken;
+            QrStartToken = qrStartToken;
+            QrStartSecret = qrStartSecret;
         }
 
         /// <summary>
@@ -25,5 +27,17 @@ namespace ActiveLogin.Authentication.BankId.Api.Models
         /// </summary>
         [DataMember(Name = "autoStartToken")]
         public string AutoStartToken { get; private set; }
+
+        /// <summary>
+        /// Used to compute the animated QR code.
+        /// </summary>
+        [DataMember(Name = "qrStartToken")]
+        public string QrStartToken { get; private set; }
+
+        /// <summary>
+        /// Used to compute the animated QR code.
+        /// </summary>
+        [DataMember(Name = "qrStartSecret")]
+        public string QrStartSecret { get; private set; }
     }
 }

--- a/src/ActiveLogin.Authentication.BankId.Api/Models/Requirement.cs
+++ b/src/ActiveLogin.Authentication.BankId.Api/Models/Requirement.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Runtime.Serialization;
 
 namespace ActiveLogin.Authentication.BankId.Api.Models
@@ -13,7 +13,7 @@ namespace ActiveLogin.Authentication.BankId.Api.Models
         /// 
         /// </summary>
         /// <param name="certificatePolicies">The oid in certificate policies in the user certificate. List of String.</param>
-        /// <param name="autoStartTokenRequired">
+        /// <param name="tokenStartRequired">
         /// If set to true, the client must have been started using the AutoStartToken.
         /// To be used if it is important that the BankID App is on the same device as the RP service.
         /// 
@@ -26,10 +26,10 @@ namespace ActiveLogin.Authentication.BankId.Api.Models
         /// If set to true, the users are allowed to use fingerprint.
         /// If set to false, the users are not allowed to use fingerprint.
         /// </param>
-        public Requirement(List<string>? certificatePolicies = null, bool? autoStartTokenRequired = null, bool? allowFingerprint = null)
+        public Requirement(List<string>? certificatePolicies = null, bool? tokenStartRequired = null, bool? allowFingerprint = null)
         {
             CertificatePolicies = certificatePolicies;
-            AutoStartTokenRequired = autoStartTokenRequired;
+            TokenStartRequired = tokenStartRequired;
             AllowFingerprint = allowFingerprint;
         }
 
@@ -45,8 +45,8 @@ namespace ActiveLogin.Authentication.BankId.Api.Models
         /// 
         /// If set to false, the client does not need to be started using the autoStartToken.
         /// </summary>
-        [DataMember(Name = "autoStartTokenRequired", EmitDefaultValue = false)]
-        public bool? AutoStartTokenRequired { get; private set; }
+        [DataMember(Name = "tokenStartRequired", EmitDefaultValue = false)]
+        public bool? TokenStartRequired { get; private set; }
 
         /// <summary>
         /// Users of iOS and Android devices may use fingerprint for authentication and signing if the device supports it and the user configured the device to use it.

--- a/src/ActiveLogin.Authentication.BankId.Api/Models/SignResponse.cs
+++ b/src/ActiveLogin.Authentication.BankId.Api/Models/SignResponse.cs
@@ -8,10 +8,12 @@ namespace ActiveLogin.Authentication.BankId.Api.Models
     [DataContract]
     public class SignResponse
     {
-        public SignResponse(string orderRef, string autoStartToken)
+        public SignResponse(string orderRef, string autoStartToken, string qrStartToken, string qrStartSecret)
         {
             OrderRef = orderRef;
             AutoStartToken = autoStartToken;
+            QrStartToken = qrStartToken;
+            QrStartSecret = qrStartSecret;
         }
 
         /// <summary>
@@ -25,5 +27,17 @@ namespace ActiveLogin.Authentication.BankId.Api.Models
         /// </summary>
         [DataMember(Name = "autoStartToken")]
         public string AutoStartToken { get; private set; }
+
+        /// <summary>
+        /// Used to compute the animated QR code.
+        /// </summary>
+        [DataMember(Name = "qrStartToken")]
+        public string QrStartToken { get; private set; }
+
+        /// <summary>
+        /// Used to compute the animated QR code.
+        /// </summary>
+        [DataMember(Name = "qrStartSecret")]
+        public string QrStartSecret { get; private set; }
     }
 }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Controllers/BankIdApiController.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Controllers/BankIdApiController.cs
@@ -153,7 +153,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthenticatio
         {
             var endUserIp = _bankIdEndUserIpResolver.GetEndUserIp(HttpContext);
             var personalIdentityNumberString = personalIdentityNumber?.To12DigitString();
-            var autoStartTokenRequired = string.IsNullOrEmpty(personalIdentityNumberString) ? true : (bool?)null;
+            var tokenStartRequired = string.IsNullOrEmpty(personalIdentityNumberString) ? true : (bool?)null;
 
             List<string>? certificatePolicies = null;
             if (loginOptions.CertificatePolicies != null && loginOptions.CertificatePolicies.Any())
@@ -161,7 +161,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthenticatio
                 certificatePolicies = loginOptions.CertificatePolicies;
             }
 
-            var authRequestRequirement = new Requirement(certificatePolicies, autoStartTokenRequired, loginOptions.AllowBiometric);
+            var authRequestRequirement = new Requirement(certificatePolicies, tokenStartRequired, loginOptions.AllowBiometric);
 
             return new AuthRequest(endUserIp, personalIdentityNumberString, authRequestRequirement);
         }


### PR DESCRIPTION
This PR fixes #275 .

Added a simplified fallback on autoStartTokenRequired for backward compatiblitity (string.replace). Thought about adding another class for v5 regarding requirement or changing it on serialization but felt a bit overkill. One perhaps could add both datamembers as well.

I've tried it out with generation of qr token with:
```csharp
        public AuthResponse Response { get; }

        public DateTime InitTime { get; } = DateTime.Now;

        /// <summary>
        /// Calculates QR token according to https://www.bankid.com/utvecklare/guider/teknisk-integrationsguide/qrkoder
        /// </summary>
        /// <param name="orderref"></param>
        /// <returns></returns>
        public string GetQrToken(string orderref)
        {
            if(Response?.OrderRef is string refOrderRef &&
                string.Equals(refOrderRef, orderref, StringComparison.InvariantCultureIgnoreCase) &&
                Response.QrStartSecret is string startSecret && Response.QrStartToken is string startToken)
            {
                var time = ((int)(DateTime.Now - InitTime).TotalSeconds).ToString();

                using (var mac = new HMACSHA256(Encoding.ASCII.GetBytes(startSecret)))
                {
                    var qrAuthBytes = mac.ComputeHash(Encoding.ASCII.GetBytes(time));
                    var qrAuthCode = string.Concat(qrAuthBytes.Select(b => string.Format("{0:x2}", b)));
                    return string.Join(".", new[] { "bankid", startToken, time, qrAuthCode });
                }
            }
            return null;
        }
```

Which works fine.