### PR TITLE
Update to .NET 6

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.100",
+    "version": "6.0.101",
     "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
This PR fixes #248 and fixes #273.
It also starts the work for #249 by removing samples for GrandID while we upgrade.

The intention is to keep the Api at .NET Standard 2.0. It's quite a simple library and by keeping it at .NET Standard .NET Framework can still use it.

All the other libraries should target .NET 6.

Following this guide:
https://docs.microsoft.com/en-us/aspnet/core/migration/31-to-60?view=aspnetcore-6.0

High level overview of this PR:

- [x] Update .NET SDK version in global.json
- [ ] Update .NET SDK version in global.json
- [ ] Update package references
- [ ] Use Minimal hosting model
- [ ] Update Razor class libraries (RCLs)
- [ ] Remove GrandID samples