### PR TITLE
Support for user data on auth request

### DIFF
--- a/docs/bankid.md
+++ b/docs/bankid.md
@@ -850,6 +850,7 @@ builder.UseAuthRequestUserData(authUserData =>
     authUserData.UserVisibleData = message.ToString();
     authUserData.UserVisibleDataFormat = BankIdUserVisibleDataFormats.SimpleMarkdownV1;
 });
+```
 
 For more advanced scenarios, you can generate the user data dynamically by implementing `IBankIdAuthRequestUserDataResolver`:
 

--- a/docs/bankid.md
+++ b/docs/bankid.md
@@ -38,6 +38,7 @@ ActiveLogin.Authentication enables an application to support Swedish BankID (sve
   + [Event listeners](#event-listeners)
   + [Store data on auth completion](#store-data-on-auth-completion)
   + [Resolve the end user ip](#resolve-the-end-user-ip)
+  + [Resolve user data on Auth request](#resolve-user-data-on-auth-request)
   + [Custom QR code generation](#custom-qr-code-generation)
   + [Custom browser detection and launch info](#custom-browser-detection-and-launch-info)
   + [Use api wrapper only](#use-api-wrapper-only)
@@ -815,6 +816,25 @@ builder.UseEndUserIpResolver(httpContext =>
 });
 ```
 
+### Resolve user data on Auth request
+
+If you want to display a text during authentication you can do it with parameter 'userVisibleData'.
+You can also add a text which will not be displayed with parameter 'userNonvisibleData' and format text in 'userVisibleData' with parameter 'userVisibleDataFormat'.
+
+You can add a static text on Program.cs:
+
+```csharp
+builder.UseAuthRequestUserData(authUserData =>
+{
+authUserData.UserVisibleData = "Message that is displayed";
+});
+```
+
+Or register a class implementing `IBankIdAuthRequestUserDataResolver`:
+
+```csharp
+services.TryAddTransient<IBankIdAuthRequestUserDataResolver, BankIdAuthRequestUserDataResolver>();
+```
 
 ### Custom QR code generation
 

--- a/docs/bankid.md
+++ b/docs/bankid.md
@@ -820,7 +820,7 @@ builder.UseEndUserIpResolver(httpContext =>
 
 BankID allows you to display a text during authentication to describe the intent. Active Login allows you to set these parameters when authenticating:
 
-![User visible data](https://alresourcesprod.blob.core.windows.net/docsassets/active-login-bankid-loggedin-screenshot.png)
+<img src="https://alresourcesprod.blob.core.windows.net/docsassets/active-login-bankid-uservisibledata-screenshot_1.jpg" width="250" alt="User visible data" />
 
 * `UserVisibleData`
 * `UserNonVisibleData`

--- a/samples/IdentityServer.ServerSample/Program.cs
+++ b/samples/IdentityServer.ServerSample/Program.cs
@@ -103,7 +103,7 @@ services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
             var message = new StringBuilder();
             message.AppendLine("# Active Login");
             message.AppendLine();
-            message.AppendLine("Welcome to the _Active Login_ demo.");
+            message.AppendLine("Welcome to the *Active Login* demo.");
 
             authUserData.UserVisibleData = message.ToString();
             authUserData.UserVisibleDataFormat = BankIdUserVisibleDataFormats.SimpleMarkdownV1;

--- a/samples/IdentityServer.ServerSample/Program.cs
+++ b/samples/IdentityServer.ServerSample/Program.cs
@@ -1,5 +1,7 @@
 using System.Globalization;
+using System.Text;
 
+using ActiveLogin.Authentication.BankId.Api;
 using ActiveLogin.Authentication.BankId.AspNetCore;
 
 using IdentityServer.ServerSample;
@@ -97,6 +99,16 @@ services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
         builder.UseQrCoderQrCodeGenerator();
         builder.UseUaParserDeviceDetection();
 
+        builder.UseAuthRequestUserData(authUserData => {
+            var message = new StringBuilder();
+            message.AppendLine("# Active Login");
+            message.AppendLine();
+            message.AppendLine("Welcome to the _Active Login_ demo.");
+
+            authUserData.UserVisibleData = message.ToString();
+            authUserData.UserVisibleDataFormat = BankIdUserVisibleDataFormats.SimpleMarkdownV1;
+        });
+
         builder.Configure(options =>
         {
             options.IssueBirthdateClaim = true;
@@ -116,6 +128,11 @@ services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
                 .UseClientCertificateFromAzureKeyVault(configuration.GetSection("ActiveLogin:BankId:ClientCertificate"));
         }
     });
+    //.UseStaticAuthUserData(new BankIdAuthUserData()
+    //{
+    //    UserVisibleData = "staticMessage"
+    //});
+  //  .UseAuthUserDataResolver<BankIdAuthUserData>();
 
 // Add MVC
 services.AddControllersWithViews()

--- a/samples/IdentityServer.ServerSample/Program.cs
+++ b/samples/IdentityServer.ServerSample/Program.cs
@@ -128,11 +128,6 @@ services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
                 .UseClientCertificateFromAzureKeyVault(configuration.GetSection("ActiveLogin:BankId:ClientCertificate"));
         }
     });
-    //.UseStaticAuthUserData(new BankIdAuthUserData()
-    //{
-    //    UserVisibleData = "staticMessage"
-    //});
-  //  .UseAuthUserDataResolver<BankIdAuthUserData>();
 
 // Add MVC
 services.AddControllersWithViews()

--- a/src/ActiveLogin.Authentication.BankId.Api/ActiveLogin.Authentication.BankId.Api.csproj
+++ b/src/ActiveLogin.Authentication.BankId.Api/ActiveLogin.Authentication.BankId.Api.csproj
@@ -12,7 +12,7 @@
         <PackageId>ActiveLogin.Authentication.BankId.Api</PackageId>
 
         <VersionPrefix>5.0.0</VersionPrefix>
-        <VersionSuffix>alpha-2</VersionSuffix>
+        <VersionSuffix>alpha-3</VersionSuffix>
         <AssemblyVersion>5.0.0.0</AssemblyVersion>
         <FileVersion Condition="'$(BUILD_BUILDNUMBER)' == ''">$(VersionPrefix).0</FileVersion>
         <FileVersion Condition="'$(BUILD_BUILDNUMBER)' != ''">$(VersionPrefix).$(BUILD_BUILDNUMBER)</FileVersion>

--- a/src/ActiveLogin.Authentication.BankId.Api/BankIdApiClientExtensions.cs
+++ b/src/ActiveLogin.Authentication.BankId.Api/BankIdApiClientExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using ActiveLogin.Authentication.BankId.Api.Models;
 
 namespace ActiveLogin.Authentication.BankId.Api
@@ -46,6 +46,35 @@ namespace ActiveLogin.Authentication.BankId.Api
         public static Task<AuthResponse> AuthAsync(this IBankIdApiClient apiClient, string endUserIp, string personalIdentityNumber)
         {
             return apiClient.AuthAsync(new AuthRequest(endUserIp, personalIdentityNumber));
+        }
+
+        /// <summary>
+        /// Initiates an authentication order. Use the collect method to query the status of the order.
+        /// </summary>
+        /// <param name="apiClient">The <see cref="IBankIdApiClient"/> instance.</param>
+        /// <param name="endUserIp">
+        /// The user IP address as seen by RP.String.IPv4 and IPv6 is allowed.
+        /// Note the importance of using the correct IP address.It must be the IP address representing the user agent (the end user device) as seen by the RP.
+        /// If there is a proxy for inbound traffic, special considerations may need to be taken to get the correct address.
+        ///
+        /// In some use cases the IP address is not available, for instance for voice based services.
+        /// In this case, the internal representation of those systems IP address is ok to use.
+        /// </param>
+        /// <param name="userVisibleData">
+        /// A text that is displayed to the user during authentication with BankID, with the
+        /// purpose of providing context for the authentication and to enable users to notice if
+        /// there is something wrong about the identification and avoid attempted frauds.The
+        /// text can be formatted using CR, LF and CRLF for new lines.The text must be
+        /// encoded as UTF-8 and then base 64 encoded. 1—1 500 characters after base 64encoding.
+        /// </param>
+        /// <param name="userVisibleDataFormat">
+        /// If present, and set to "simpleMarkdownV1", this parameter indicates that userVisibleData holds formatting characters which, if used correctly, will make the text displayed with the user nicer to look at.
+        /// For further information of formatting options, please study the document Guidelines for Formatted Text.
+        /// </param>
+        /// <returns>If the request is successful, the OrderRef and AutoStartToken is returned.</returns>
+        public static Task<AuthResponse> AuthAsync(this IBankIdApiClient apiClient, string endUserIp, string userVisibleData, string userVisibleDataFormat)
+        {
+            return apiClient.AuthAsync(new AuthRequest(endUserIp, null, null, userVisibleData, null, userVisibleDataFormat));
         }
 
         /// <summary>

--- a/src/ActiveLogin.Authentication.BankId.Api/Models/AuthRequest.cs
+++ b/src/ActiveLogin.Authentication.BankId.Api/Models/AuthRequest.cs
@@ -20,7 +20,7 @@ namespace ActiveLogin.Authentication.BankId.Api.Models
         /// In this case, the internal representation of those systems IP address is ok to use.
         /// </param>
         public AuthRequest(string endUserIp)
-            : this(endUserIp, null, null, null, new Requirement(), null)
+            : this(endUserIp, null, new Requirement(), null, null, null)
         {
         }
 
@@ -38,28 +38,7 @@ namespace ActiveLogin.Authentication.BankId.Api.Models
         /// If the personal number is excluded, the client must be started with the AutoStartToken returned in the response.
         /// </param>
         public AuthRequest(string endUserIp, string personalIdentityNumber)
-            : this(endUserIp, null, null, personalIdentityNumber, new Requirement(), null)
-        {
-        }
-
-        /// <summary></summary>
-        /// <param name="endUserIp">
-        /// The user IP address as seen by RP. IPv4 and IPv6 is allowed.
-        /// Note the importance of using the correct IP address.It must be the IP address representing the user agent (the end user device) as seen by the RP.
-        /// If there is a proxy for inbound traffic, special considerations may need to be taken to get the correct address.
-        ///
-        /// In some use cases the IP address is not available, for instance for voice based services.
-        /// In this case, the internal representation of those systems IP address is ok to use.
-        /// </param>
-        /// <param name="userVisibleData">
-        /// The text to be displayed and signed. The text can be formatted using CR, LF and CRLF for new lines.
-        /// </param>
-        /// <param name="personalIdentityNumber">
-        /// The personal number of the user. 12 digits, century must be included (YYYYMMDDSSSC).
-        /// If the personal number is excluded, the client must be started with the AutoStartToken returned in the response.
-        /// </param>
-        public AuthRequest(string endUserIp, string userVisibleData, string personalIdentityNumber)
-            : this(endUserIp, userVisibleData, null, personalIdentityNumber, new Requirement(), null)
+            : this(endUserIp, personalIdentityNumber, new Requirement(), null, null, null)
         {
         }
 
@@ -78,7 +57,7 @@ namespace ActiveLogin.Authentication.BankId.Api.Models
         /// </param>
         /// <param name="requirement">Requirements on how the auth or sign order must be performed.</param>
         public AuthRequest(string endUserIp, string? personalIdentityNumber, Requirement requirement)
-            : this(endUserIp, null, null, personalIdentityNumber, requirement, null)
+            : this(endUserIp, personalIdentityNumber, requirement, null, null, null)
         {
         }
 
@@ -96,11 +75,14 @@ namespace ActiveLogin.Authentication.BankId.Api.Models
         /// If the personal number is excluded, the client must be started with the AutoStartToken returned in the response.
         /// </param>
         /// <param name="userVisibleData">
-        /// The text to be displayed and signed. The text can be formatted using CR, LF and CRLF for new lines.
+        /// A text that is displayed to the user during authentication with BankID, with the
+        /// purpose of providing context for the authentication and to enable users to notice if
+        /// there is something wrong about the identification and avoid attempted frauds.The
+        /// text can be formatted using CR, LF and CRLF for new lines.The text must be
+        /// encoded as UTF-8 and then base 64 encoded. 1—1 500 characters after base 64encoding.
         /// </param>
-        /// <param name="requirement">Requirements on how the auth or sign order must be performed.</param>
-        public AuthRequest(string endUserIp, string? userVisibleData, string? personalIdentityNumber, Requirement requirement)
-            : this(endUserIp, userVisibleData, null, personalIdentityNumber, requirement, null)
+        public AuthRequest(string endUserIp, string personalIdentityNumber, string userVisibleData)
+            : this(endUserIp, personalIdentityNumber, new Requirement(), userVisibleData, null, null)
         {
         }
 
@@ -119,13 +101,43 @@ namespace ActiveLogin.Authentication.BankId.Api.Models
         /// </param>
         /// <param name="requirement">Requirements on how the auth or sign order must be performed.</param>
         /// <param name="userVisibleData">
-        /// The text to be displayed and signed. The text can be formatted using CR, LF and CRLF for new lines.
+        /// A text that is displayed to the user during authentication with BankID, with the
+        /// purpose of providing context for the authentication and to enable users to notice if
+        /// there is something wrong about the identification and avoid attempted frauds.The
+        /// text can be formatted using CR, LF and CRLF for new lines.The text must be
+        /// encoded as UTF-8 and then base 64 encoded. 1—1 500 characters after base 64encoding.
+        /// </param>
+        public AuthRequest(string endUserIp, string? personalIdentityNumber, Requirement requirement, string? userVisibleData)
+            : this(endUserIp, personalIdentityNumber, requirement, userVisibleData, null, null)
+        {
+        }
+
+        /// <summary></summary>
+        /// <param name="endUserIp">
+        /// The user IP address as seen by RP. IPv4 and IPv6 is allowed.
+        /// Note the importance of using the correct IP address.It must be the IP address representing the user agent (the end user device) as seen by the RP.
+        /// If there is a proxy for inbound traffic, special considerations may need to be taken to get the correct address.
+        ///
+        /// In some use cases the IP address is not available, for instance for voice based services.
+        /// In this case, the internal representation of those systems IP address is ok to use.
+        /// </param>
+        /// <param name="personalIdentityNumber">
+        /// The personal number of the user. 12 digits, century must be included (YYYYMMDDSSSC).
+        /// If the personal number is excluded, the client must be started with the AutoStartToken returned in the response.
+        /// </param>
+        /// <param name="requirement">Requirements on how the auth or sign order must be performed.</param>
+        /// <param name="userVisibleData">
+        /// A text that is displayed to the user during authentication with BankID, with the
+        /// purpose of providing context for the authentication and to enable users to notice if
+        /// there is something wrong about the identification and avoid attempted frauds.The
+        /// text can be formatted using CR, LF and CRLF for new lines.The text must be
+        /// encoded as UTF-8 and then base 64 encoded. 1—1 500 characters after base 64encoding.
         /// </param>
         /// <param name="userNonVisibleData">
         /// Data not displayed to the user. String. The value must be base 64-encoded. 1-1 500 characters after base 64-encoding
         /// </param>
-        public AuthRequest(string endUserIp, string? userVisibleData, byte[]? userNonVisibleData, string? personalIdentityNumber, Requirement? requirement)
-            : this(endUserIp, userVisibleData, userNonVisibleData, personalIdentityNumber, requirement, null)
+        public AuthRequest(string endUserIp, string? personalIdentityNumber, Requirement requirement, string? userVisibleData, byte[]? userNonVisibleData)
+            : this(endUserIp, personalIdentityNumber, requirement, userVisibleData, userNonVisibleData, null)
         {
         }
 
@@ -139,7 +151,11 @@ namespace ActiveLogin.Authentication.BankId.Api.Models
         /// In this case, the internal representation of those systems IP address is ok to use.
         /// </param>
         /// <param name="userVisibleData">
-        /// The text to be displayed and signed. The text can be formatted using CR, LF and CRLF for new lines.
+        /// A text that is displayed to the user during authentication with BankID, with the
+        /// purpose of providing context for the authentication and to enable users to notice if
+        /// there is something wrong about the identification and avoid attempted frauds.The
+        /// text can be formatted using CR, LF and CRLF for new lines.The text must be
+        /// encoded as UTF-8 and then base 64 encoded. 1—1 500 characters after base 64encoding.
         /// </param>
         /// <param name="userNonVisibleData">
         /// Data not displayed to the user.
@@ -153,13 +169,13 @@ namespace ActiveLogin.Authentication.BankId.Api.Models
         /// If present, and set to "simpleMarkdownV1", this parameter indicates that userVisibleData holds formatting characters which, if used correctly, will make the text displayed with the user nicer to look at.
         /// For further information of formatting options, please study the document Guidelines for Formatted Text.
         /// </param>
-        public AuthRequest(string endUserIp, string? userVisibleData, byte[]? userNonVisibleData, string? personalIdentityNumber, Requirement? requirement, string? userVisibleDataFormat)
+        public AuthRequest(string endUserIp, string? personalIdentityNumber, Requirement? requirement, string? userVisibleData, byte[]? userNonVisibleData, string? userVisibleDataFormat)
         {
             EndUserIp = endUserIp ?? throw new ArgumentNullException(nameof(endUserIp));
-            UserVisibleData = ToBase64EncodedString(userVisibleData);
             PersonalIdentityNumber = personalIdentityNumber;
-            UserNonVisibleData = ToBase64EncodedString(userNonVisibleData);
             Requirement = requirement ?? new Requirement();
+            UserVisibleData = ToBase64EncodedString(userVisibleData);
+            UserNonVisibleData = ToBase64EncodedString(userNonVisibleData);
             UserVisibleDataFormat = userVisibleDataFormat;
         }
 

--- a/src/ActiveLogin.Authentication.BankId.Api/Models/AuthRequest.cs
+++ b/src/ActiveLogin.Authentication.BankId.Api/Models/AuthRequest.cs
@@ -1,4 +1,6 @@
-﻿using System.Runtime.Serialization;
+using System;
+using System.Runtime.Serialization;
+using System.Text;
 
 namespace ActiveLogin.Authentication.BankId.Api.Models
 {
@@ -18,7 +20,7 @@ namespace ActiveLogin.Authentication.BankId.Api.Models
         /// In this case, the internal representation of those systems IP address is ok to use.
         /// </param>
         public AuthRequest(string endUserIp)
-            : this(endUserIp, null, new Requirement())
+            : this(endUserIp, null, null, null, new Requirement(), null)
         {
         }
 
@@ -36,7 +38,28 @@ namespace ActiveLogin.Authentication.BankId.Api.Models
         /// If the personal number is excluded, the client must be started with the AutoStartToken returned in the response.
         /// </param>
         public AuthRequest(string endUserIp, string personalIdentityNumber)
-            : this(endUserIp, personalIdentityNumber, new Requirement())
+            : this(endUserIp, null, null, personalIdentityNumber, new Requirement(), null)
+        {
+        }
+
+        /// <summary></summary>
+        /// <param name="endUserIp">
+        /// The user IP address as seen by RP. IPv4 and IPv6 is allowed.
+        /// Note the importance of using the correct IP address.It must be the IP address representing the user agent (the end user device) as seen by the RP.
+        /// If there is a proxy for inbound traffic, special considerations may need to be taken to get the correct address.
+        ///
+        /// In some use cases the IP address is not available, for instance for voice based services.
+        /// In this case, the internal representation of those systems IP address is ok to use.
+        /// </param>
+        /// <param name="userVisibleData">
+        /// The text to be displayed and signed. The text can be formatted using CR, LF and CRLF for new lines.
+        /// </param>
+        /// <param name="personalIdentityNumber">
+        /// The personal number of the user. 12 digits, century must be included (YYYYMMDDSSSC).
+        /// If the personal number is excluded, the client must be started with the AutoStartToken returned in the response.
+        /// </param>
+        public AuthRequest(string endUserIp, string userVisibleData, string personalIdentityNumber)
+            : this(endUserIp, userVisibleData, null, personalIdentityNumber, new Requirement(), null)
         {
         }
 
@@ -55,10 +78,89 @@ namespace ActiveLogin.Authentication.BankId.Api.Models
         /// </param>
         /// <param name="requirement">Requirements on how the auth or sign order must be performed.</param>
         public AuthRequest(string endUserIp, string? personalIdentityNumber, Requirement requirement)
+            : this(endUserIp, null, null, personalIdentityNumber, requirement, null)
         {
-            EndUserIp = endUserIp;
+        }
+
+        /// <summary></summary>
+        /// <param name="endUserIp">
+        /// The user IP address as seen by RP. IPv4 and IPv6 is allowed.
+        /// Note the importance of using the correct IP address.It must be the IP address representing the user agent (the end user device) as seen by the RP.
+        /// If there is a proxy for inbound traffic, special considerations may need to be taken to get the correct address.
+        ///
+        /// In some use cases the IP address is not available, for instance for voice based services.
+        /// In this case, the internal representation of those systems IP address is ok to use.
+        /// </param>
+        /// <param name="personalIdentityNumber">
+        /// The personal number of the user. 12 digits, century must be included (YYYYMMDDSSSC).
+        /// If the personal number is excluded, the client must be started with the AutoStartToken returned in the response.
+        /// </param>
+        /// <param name="userVisibleData">
+        /// The text to be displayed and signed. The text can be formatted using CR, LF and CRLF for new lines.
+        /// </param>
+        /// <param name="requirement">Requirements on how the auth or sign order must be performed.</param>
+        public AuthRequest(string endUserIp, string? userVisibleData, string? personalIdentityNumber, Requirement requirement)
+            : this(endUserIp, userVisibleData, null, personalIdentityNumber, requirement, null)
+        {
+        }
+
+        /// <summary></summary>
+        /// <param name="endUserIp">
+        /// The user IP address as seen by RP. IPv4 and IPv6 is allowed.
+        /// Note the importance of using the correct IP address.It must be the IP address representing the user agent (the end user device) as seen by the RP.
+        /// If there is a proxy for inbound traffic, special considerations may need to be taken to get the correct address.
+        ///
+        /// In some use cases the IP address is not available, for instance for voice based services.
+        /// In this case, the internal representation of those systems IP address is ok to use.
+        /// </param>
+        /// <param name="personalIdentityNumber">
+        /// The personal number of the user. 12 digits, century must be included (YYYYMMDDSSSC).
+        /// If the personal number is excluded, the client must be started with the AutoStartToken returned in the response.
+        /// </param>
+        /// <param name="requirement">Requirements on how the auth or sign order must be performed.</param>
+        /// <param name="userVisibleData">
+        /// The text to be displayed and signed. The text can be formatted using CR, LF and CRLF for new lines.
+        /// </param>
+        /// <param name="userNonVisibleData">
+        /// Data not displayed to the user. String. The value must be base 64-encoded. 1-1 500 characters after base 64-encoding
+        /// </param>
+        public AuthRequest(string endUserIp, string? userVisibleData, byte[]? userNonVisibleData, string? personalIdentityNumber, Requirement? requirement)
+            : this(endUserIp, userVisibleData, userNonVisibleData, personalIdentityNumber, requirement, null)
+        {
+        }
+
+        /// <summary></summary>
+        /// <param name="endUserIp">
+        /// The user IP address as seen by RP. IPv4 and IPv6 is allowed.
+        /// Note the importance of using the correct IP address.It must be the IP address representing the user agent (the end user device) as seen by the RP.
+        /// If there is a proxy for inbound traffic, special considerations may need to be taken to get the correct address.
+        /// 
+        /// In some use cases the IP address is not available, for instance for voice based services.
+        /// In this case, the internal representation of those systems IP address is ok to use.
+        /// </param>
+        /// <param name="userVisibleData">
+        /// The text to be displayed and signed. The text can be formatted using CR, LF and CRLF for new lines.
+        /// </param>
+        /// <param name="userNonVisibleData">
+        /// Data not displayed to the user.
+        /// </param>
+        /// <param name="personalIdentityNumber">
+        /// The personal number of the user. 12 digits, century must be included (YYYYMMDDSSSC).
+        /// If the personal number is excluded, the client must be started with the AutoStartToken returned in the response.
+        /// </param>
+        /// <param name="requirement">Requirements on how the auth or sign order must be performed.</param>
+        /// <param name="userVisibleDataFormat">
+        /// If present, and set to "simpleMarkdownV1", this parameter indicates that userVisibleData holds formatting characters which, if used correctly, will make the text displayed with the user nicer to look at.
+        /// For further information of formatting options, please study the document Guidelines for Formatted Text.
+        /// </param>
+        public AuthRequest(string endUserIp, string? userVisibleData, byte[]? userNonVisibleData, string? personalIdentityNumber, Requirement? requirement, string? userVisibleDataFormat)
+        {
+            EndUserIp = endUserIp ?? throw new ArgumentNullException(nameof(endUserIp));
+            UserVisibleData = ToBase64EncodedString(userVisibleData);
             PersonalIdentityNumber = personalIdentityNumber;
-            Requirement = requirement;
+            UserNonVisibleData = ToBase64EncodedString(userNonVisibleData);
+            Requirement = requirement ?? new Requirement();
+            UserVisibleDataFormat = userVisibleDataFormat;
         }
 
         /// <summary>
@@ -84,5 +186,51 @@ namespace ActiveLogin.Authentication.BankId.Api.Models
         /// </summary>
         [DataMember(Name = "requirement", EmitDefaultValue = false)]
         public Requirement Requirement { get; private set; }
+
+        /// <summary>
+        /// A text that is displayed to the user during authentication with BankID, with the
+        /// purpose of providing context for the authentication and to enable users to notice if
+        /// there is something wrong about the identification and avoid attempted frauds.The
+        /// text can be formatted using CR, LF and CRLF for new lines.The text must be
+        /// encoded as UTF-8 and then base 64 encoded. 1—1 500 characters after base 64encoding.
+        /// </summary>
+        [DataMember(Name = "userVisibleData", EmitDefaultValue = false)]
+        public string? UserVisibleData { get; private set; }
+
+        /// <summary>
+        /// Data not displayed to the user. String. The value must be base 64-encoded. 1-1 500
+        /// characters after base 64-encoding
+        /// </summary>
+        [DataMember(Name = "userNonVisibleData", EmitDefaultValue = false)]
+        public string? UserNonVisibleData { get; private set; }
+
+        /// <summary>
+        /// If present, and set to “simpleMarkdownV1”, this parameter indicates that
+        /// userVisibleData holds formatting characters which, if used correctly, will make
+        /// the text displayed with the user nicer to look at.For further information of
+        /// formatting options, please study the document Guidelines for Formatted Text.
+        /// </summary>
+        [DataMember(Name = "userVisibleDataFormat", EmitDefaultValue = false)]
+        public string? UserVisibleDataFormat { get; private set; }
+
+        private static string? ToBase64EncodedString(string? value)
+        {
+            if (value == null)
+            {
+                return null;
+            }
+
+            return Convert.ToBase64String(Encoding.UTF8.GetBytes(value));
+        }
+
+        private static string? ToBase64EncodedString(byte[]? value)
+        {
+            if (value == null)
+            {
+                return null;
+            }
+
+            return Convert.ToBase64String(value);
+        }
     }
 }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore.Azure/ActiveLogin.Authentication.BankId.AspNetCore.Azure.csproj
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore.Azure/ActiveLogin.Authentication.BankId.AspNetCore.Azure.csproj
@@ -12,7 +12,7 @@
         <PackageId>ActiveLogin.Authentication.BankId.AspNetCore.Azure</PackageId>
 
         <VersionPrefix>5.0.0</VersionPrefix>
-        <VersionSuffix>alpha-2</VersionSuffix>
+        <VersionSuffix>alpha-3</VersionSuffix>
         <AssemblyVersion>5.0.0.0</AssemblyVersion>
         <FileVersion Condition="'$(BUILD_BUILDNUMBER)' == ''">$(VersionPrefix).0</FileVersion>
         <FileVersion Condition="'$(BUILD_BUILDNUMBER)' != ''">$(VersionPrefix).$(BUILD_BUILDNUMBER)</FileVersion>

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore.AzureMonitor/ActiveLogin.Authentication.BankId.AspNetCore.AzureMonitor.csproj
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore.AzureMonitor/ActiveLogin.Authentication.BankId.AspNetCore.AzureMonitor.csproj
@@ -12,7 +12,7 @@
         <PackageId>ActiveLogin.Authentication.BankId.AspNetCore.AzureMonitor</PackageId>
 
         <VersionPrefix>5.0.0</VersionPrefix>
-        <VersionSuffix>alpha-2</VersionSuffix>
+        <VersionSuffix>alpha-3</VersionSuffix>
         <AssemblyVersion>5.0.0.0</AssemblyVersion>
         <FileVersion Condition="'$(BUILD_BUILDNUMBER)' == ''">$(VersionPrefix).0</FileVersion>
         <FileVersion Condition="'$(BUILD_BUILDNUMBER)' != ''">$(VersionPrefix).$(BUILD_BUILDNUMBER)</FileVersion>

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore.QRCoder/ActiveLogin.Authentication.BankId.AspNetCore.QRCoder.csproj
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore.QRCoder/ActiveLogin.Authentication.BankId.AspNetCore.QRCoder.csproj
@@ -13,7 +13,7 @@
         <RootNamespace>ActiveLogin.Authentication.BankId.AspNetCore.QrCoder</RootNamespace>
 
         <VersionPrefix>5.0.0</VersionPrefix>
-        <VersionSuffix>alpha-2</VersionSuffix>
+        <VersionSuffix>alpha-3</VersionSuffix>
         <AssemblyVersion>5.0.0.0</AssemblyVersion>
         <FileVersion Condition="'$(BUILD_BUILDNUMBER)' == ''">$(VersionPrefix).0</FileVersion>
         <FileVersion Condition="'$(BUILD_BUILDNUMBER)' != ''">$(VersionPrefix).$(BUILD_BUILDNUMBER)</FileVersion>

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore.UAParser/ActiveLogin.Authentication.BankId.AspNetCore.UAParser.csproj
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore.UAParser/ActiveLogin.Authentication.BankId.AspNetCore.UAParser.csproj
@@ -13,7 +13,7 @@
         <RootNamespace>ActiveLogin.Authentication.BankId.AspNetCore.UaParser</RootNamespace>
 
         <VersionPrefix>5.0.0</VersionPrefix>
-        <VersionSuffix>alpha-2</VersionSuffix>
+        <VersionSuffix>alpha-3</VersionSuffix>
         <AssemblyVersion>5.0.0.0</AssemblyVersion>
         <FileVersion Condition="'$(BUILD_BUILDNUMBER)' == ''">$(VersionPrefix).0</FileVersion>
         <FileVersion Condition="'$(BUILD_BUILDNUMBER)' != ''">$(VersionPrefix).$(BUILD_BUILDNUMBER)</FileVersion>

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/ActiveLogin.Authentication.BankId.AspNetCore.csproj
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/ActiveLogin.Authentication.BankId.AspNetCore.csproj
@@ -14,7 +14,7 @@
         <PackageId>ActiveLogin.Authentication.BankId.AspNetCore</PackageId>
 
         <VersionPrefix>5.0.0</VersionPrefix>
-        <VersionSuffix>alpha-2</VersionSuffix>
+        <VersionSuffix>alpha-3</VersionSuffix>
         <AssemblyVersion>5.0.0.0</AssemblyVersion>
         <FileVersion Condition="'$(BUILD_BUILDNUMBER)' == ''">$(VersionPrefix).0</FileVersion>
         <FileVersion Condition="'$(BUILD_BUILDNUMBER)' != ''">$(VersionPrefix).$(BUILD_BUILDNUMBER)</FileVersion>

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Controllers/BankIdApiController.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Controllers/BankIdApiController.cs
@@ -167,9 +167,9 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthenticatio
             var authRequestRequirement = new Requirement(certificatePolicies, tokenStartRequired, loginOptions.AllowBiometric);
 
             var authRequestContext = new BankIdAuthRequestContext(endUserIp, personalIdentityNumberString, authRequestRequirement);
-            var userData = _bankIdAuthUserDataResolver.GetUserData(authRequestContext, HttpContext);
+            var userData = _bankIdAuthUserDataResolver.GetUserDataAsync(authRequestContext, HttpContext);
   
-            return new AuthRequest(endUserIp, userData.UserVisibleData, userData.UserNonVisibleData, personalIdentityNumberString, authRequestRequirement, userData.UserVisibleDataFormat);
+            return new AuthRequest(endUserIp, personalIdentityNumberString, authRequestRequirement, userData.Result.UserVisibleData, userData.Result.UserNonVisibleData, userData.Result.UserVisibleDataFormat);
         }
 
         private BankIdLaunchInfo GetBankIdLaunchInfo(BankIdLoginApiInitializeRequest request, AuthResponse authResponse)

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Controllers/BankIdApiController.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/BankIdAuthentication/Controllers/BankIdApiController.cs
@@ -112,7 +112,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthenticatio
             AuthResponse authResponse;
             try
             {
-                var authRequest = GetAuthRequest(personalIdentityNumber, unprotectedLoginOptions);
+                var authRequest = await GetAuthRequest(personalIdentityNumber, unprotectedLoginOptions);
                 authResponse = await _bankIdApiClient.AuthAsync(authRequest);
             }
             catch (BankIdApiException bankIdApiException)
@@ -152,7 +152,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthenticatio
             return OkJsonResult(BankIdLoginApiInitializeResponse.ManualLaunch(protectedOrderRef));
         }
         
-        private AuthRequest GetAuthRequest(SwedishPersonalIdentityNumber? personalIdentityNumber, BankIdLoginOptions loginOptions)
+        private async Task<AuthRequest> GetAuthRequest(SwedishPersonalIdentityNumber? personalIdentityNumber, BankIdLoginOptions loginOptions)
         {
             var endUserIp = _bankIdEndUserIpResolver.GetEndUserIp(HttpContext);
             var personalIdentityNumberString = personalIdentityNumber?.To12DigitString();
@@ -167,9 +167,9 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.BankIdAuthenticatio
             var authRequestRequirement = new Requirement(certificatePolicies, tokenStartRequired, loginOptions.AllowBiometric);
 
             var authRequestContext = new BankIdAuthRequestContext(endUserIp, personalIdentityNumberString, authRequestRequirement);
-            var userData = _bankIdAuthUserDataResolver.GetUserDataAsync(authRequestContext, HttpContext);
+            var userData = await _bankIdAuthUserDataResolver.GetUserDataAsync(authRequestContext, HttpContext);
   
-            return new AuthRequest(endUserIp, personalIdentityNumberString, authRequestRequirement, userData.Result.UserVisibleData, userData.Result.UserNonVisibleData, userData.Result.UserVisibleDataFormat);
+            return new AuthRequest(endUserIp, personalIdentityNumberString, authRequestRequirement, userData.UserVisibleData, userData.UserNonVisibleData, userData.UserVisibleDataFormat);
         }
 
         private BankIdLaunchInfo GetBankIdLaunchInfo(BankIdLoginApiInitializeRequest request, AuthResponse authResponse)

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdAuthRequestContext.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdAuthRequestContext.cs
@@ -1,0 +1,20 @@
+using ActiveLogin.Authentication.BankId.Api.Models;
+
+namespace ActiveLogin.Authentication.BankId.AspNetCore
+{
+    public class BankIdAuthRequestContext
+    {
+        public BankIdAuthRequestContext(string endUserIp, string? personalIdentityNumber, Requirement requirement)
+        {
+            EndUserIp = endUserIp;
+            PersonalIdentityNumber = personalIdentityNumber;
+            Requirement = requirement;
+        }
+
+        public string EndUserIp { get; private set; }
+       
+        public string? PersonalIdentityNumber { get; private set; }
+
+        public Requirement Requirement { get; private set; }
+    }
+}

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdAuthRequestEmptyUserDataResolver.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdAuthRequestEmptyUserDataResolver.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Http;
+
+namespace ActiveLogin.Authentication.BankId.AspNetCore
+{
+    internal class BankIdAuthRequestEmptyUserDataResolver : IBankIdAuthRequestUserDataResolver
+    {
+        private static readonly BankIdAuthUserData _emptyAuthUserData = new();
+
+        public BankIdAuthUserData GetUserData(BankIdAuthRequestContext authRequestContext, HttpContext httpContext)
+        {
+            return _emptyAuthUserData;
+        }
+    }
+}

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdAuthRequestEmptyUserDataResolver.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdAuthRequestEmptyUserDataResolver.cs
@@ -1,3 +1,5 @@
+using System.Threading.Tasks;
+
 using Microsoft.AspNetCore.Http;
 
 namespace ActiveLogin.Authentication.BankId.AspNetCore
@@ -6,9 +8,9 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore
     {
         private static readonly BankIdAuthUserData _emptyAuthUserData = new();
 
-        public BankIdAuthUserData GetUserData(BankIdAuthRequestContext authRequestContext, HttpContext httpContext)
+        public async Task<BankIdAuthUserData> GetUserDataAsync(BankIdAuthRequestContext authRequestContext, HttpContext httpContext)
         {
-            return _emptyAuthUserData;
+            return await Task.FromResult(_emptyAuthUserData);
         }
     }
 }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdAuthRequestStaticUserDataResolver.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdAuthRequestStaticUserDataResolver.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.AspNetCore.Http;
+using System.Threading.Tasks;
+
+using Microsoft.AspNetCore.Http;
 
 namespace ActiveLogin.Authentication.BankId.AspNetCore
 {
@@ -11,9 +13,9 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore
             _authUserData = authUserData;
         }
 
-        public BankIdAuthUserData GetUserData(BankIdAuthRequestContext authRequestContext, HttpContext httpContext)
+        public async Task<BankIdAuthUserData> GetUserDataAsync(BankIdAuthRequestContext authRequestContext, HttpContext httpContext)
         {
-            return _authUserData;
+            return await Task.FromResult(_authUserData);
         }
     }
 }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdAuthRequestStaticUserDataResolver.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdAuthRequestStaticUserDataResolver.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.AspNetCore.Http;
+
+namespace ActiveLogin.Authentication.BankId.AspNetCore
+{
+    internal class BankIdAuthRequestStaticUserDataResolver : IBankIdAuthRequestUserDataResolver
+    {
+        private readonly BankIdAuthUserData _authUserData;
+
+        public BankIdAuthRequestStaticUserDataResolver(BankIdAuthUserData authUserData)
+        {
+            _authUserData = authUserData;
+        }
+
+        public BankIdAuthUserData GetUserData(BankIdAuthRequestContext authRequestContext, HttpContext httpContext)
+        {
+            return _authUserData;
+        }
+    }
+}

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdAuthUserData.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdAuthUserData.cs
@@ -1,0 +1,9 @@
+namespace ActiveLogin.Authentication.BankId.AspNetCore
+{
+    public class BankIdAuthUserData
+    {
+        public string? UserVisibleData { get; set; }
+        public byte[]? UserNonVisibleData { get; set; }
+        public string? UserVisibleDataFormat { get; set; }
+    }
+}

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdBuilderExtensions.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdBuilderExtensions.cs
@@ -171,7 +171,7 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             var authUserDataResult = new BankIdAuthUserData();
             authUserData(authUserDataResult);
-            UseAuthRequestUserData(builder, authUserData);
+            UseAuthRequestUserData(builder, authUserDataResult);
 
             return builder;
         }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdBuilderExtensions.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdBuilderExtensions.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Net.Http.Headers;
-using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 
 using ActiveLogin.Authentication.BankId.Api.UserMessage;
@@ -48,6 +47,8 @@ namespace Microsoft.Extensions.DependencyInjection
             services.TryAddTransient<IBankIdQrCodeGenerator, BankIdMissingQrCodeGenerator>();
 
             services.TryAddTransient<IBankIdEventTrigger, BankIdEventTrigger>();
+
+            services.TryAddTransient<IBankIdAuthRequestUserDataResolver, BankIdAuthRequestEmptyUserDataResolver>();
 
             builder.UseEndUserIpResolver<BankIdRemoteIpAddressEndUserIpResolver>();
 
@@ -143,6 +144,34 @@ namespace Microsoft.Extensions.DependencyInjection
         public static IBankIdBuilder UseEndUserIpResolver(this IBankIdBuilder builder, Func<HttpContext, string> resolver)
         {
             builder.AuthenticationBuilder.Services.AddTransient<IBankIdEndUserIpResolver>(x => new BankIdDynamicEndUserIpResolver(resolver));
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Set what user data to supply to the auth request.
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="authUserData"></param>
+        /// <returns></returns>
+        public static IBankIdBuilder UseAuthRequestUserData(this IBankIdBuilder builder, BankIdAuthUserData authUserData)
+        {
+            builder.AuthenticationBuilder.Services.AddTransient<IBankIdAuthRequestUserDataResolver>(x => new BankIdAuthRequestStaticUserDataResolver(authUserData));
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Set what user data to supply to the auth request.
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="authUserData"></param>
+        /// <returns></returns>
+        public static IBankIdBuilder UseAuthRequestUserData(this IBankIdBuilder builder, Action<BankIdAuthUserData> authUserData)
+        {
+            var authUserDataResult = new BankIdAuthUserData();
+            authUserData(authUserDataResult);
+            UseAuthRequestUserData(builder, authUserData);
 
             return builder;
         }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/IBankIdAuthRequestUserDataResolver.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/IBankIdAuthRequestUserDataResolver.cs
@@ -1,3 +1,5 @@
+using System.Threading.Tasks;
+
 using Microsoft.AspNetCore.Http;
 
 namespace ActiveLogin.Authentication.BankId.AspNetCore
@@ -13,6 +15,6 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore
         /// <param name="authRequestContext">BankID auth request context.</param>
         /// <param name="httpContext">HttpContext for the current http request.</param>
         /// <returns></returns>
-        BankIdAuthUserData GetUserData(BankIdAuthRequestContext authRequestContext, HttpContext httpContext);
+        Task<BankIdAuthUserData> GetUserDataAsync(BankIdAuthRequestContext authRequestContext, HttpContext httpContext);
     }
 }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/IBankIdAuthRequestUserDataResolver.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/IBankIdAuthRequestUserDataResolver.cs
@@ -1,0 +1,18 @@
+using Microsoft.AspNetCore.Http;
+
+namespace ActiveLogin.Authentication.BankId.AspNetCore
+{
+    /// <summary>
+    /// Resolve auth request user data.
+    /// </summary>
+    public interface IBankIdAuthRequestUserDataResolver
+    {
+        /// <summary>
+        /// Returns the user data for the current context/request.
+        /// </summary>
+        /// <param name="authRequestContext">BankID auth request context.</param>
+        /// <param name="httpContext">HttpContext for the current http request.</param>
+        /// <returns></returns>
+        BankIdAuthUserData GetUserData(BankIdAuthRequestContext authRequestContext, HttpContext httpContext);
+    }
+}

--- a/test/ActiveLogin.Authentication.BankId.Api.Test/BankIdApiClientExtensions_Tests.cs
+++ b/test/ActiveLogin.Authentication.BankId.Api.Test/BankIdApiClientExtensions_Tests.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using ActiveLogin.Authentication.BankId.Api.Models;
 using ActiveLogin.Authentication.BankId.Api.Test.TestHelpers;
 using Moq;
@@ -19,7 +19,7 @@ namespace ActiveLogin.Authentication.BankId.Api.Test
                                .ReturnsAsync(It.IsAny<AuthResponse>());
 
             // Act
-            await BankIdApiClientExtensions.AuthAsync(bankIdApiClientMock.Object, "1.1.1.1", null);
+            await BankIdApiClientExtensions.AuthAsync(bankIdApiClientMock.Object, "1.1.1.1");
 
             // Assert
             var request = bankIdApiClientMock.GetFirstArgumentOfFirstInvocation<IBankIdApiClient, AuthRequest>();
@@ -42,6 +42,24 @@ namespace ActiveLogin.Authentication.BankId.Api.Test
             var request = bankIdApiClientMock.GetFirstArgumentOfFirstInvocation<IBankIdApiClient, AuthRequest>();
             Assert.Equal("1.1.1.1", request.EndUserIp);
             Assert.Equal("201801012392", request.PersonalIdentityNumber);
+        }
+
+        [Fact]
+        public async Task AuthAsync_WithEndUserIp_AndUserData_ShouldMap_ToAuthRequest_WithEndUserIp_AndUserData_Base64Encoded()
+        {
+            // Arrange
+            var bankIdApiClientMock = new Mock<IBankIdApiClient>(MockBehavior.Strict);
+            bankIdApiClientMock.Setup(client => client.AuthAsync(It.IsAny<AuthRequest>()))
+                .ReturnsAsync(It.IsAny<AuthResponse>());
+
+            // Act
+            await BankIdApiClientExtensions.AuthAsync(bankIdApiClientMock.Object, "1.1.1.1", "userVisibleData", "userVisibleDataFormat");
+
+            // Assert
+            var request = bankIdApiClientMock.GetFirstArgumentOfFirstInvocation<IBankIdApiClient, AuthRequest>();
+            Assert.Equal("1.1.1.1", request.EndUserIp);
+            Assert.Equal("dXNlclZpc2libGVEYXRh", request.UserVisibleData);
+            Assert.Equal("userVisibleDataFormat", request.UserVisibleDataFormat);
         }
 
         [Fact]

--- a/test/ActiveLogin.Authentication.BankId.Api.Test/BankIdApiClientExtensions_Tests.cs
+++ b/test/ActiveLogin.Authentication.BankId.Api.Test/BankIdApiClientExtensions_Tests.cs
@@ -19,7 +19,7 @@ namespace ActiveLogin.Authentication.BankId.Api.Test
                                .ReturnsAsync(It.IsAny<AuthResponse>());
 
             // Act
-            await BankIdApiClientExtensions.AuthAsync(bankIdApiClientMock.Object, "1.1.1.1");
+            await BankIdApiClientExtensions.AuthAsync(bankIdApiClientMock.Object, "1.1.1.1", null);
 
             // Assert
             var request = bankIdApiClientMock.GetFirstArgumentOfFirstInvocation<IBankIdApiClient, AuthRequest>();

--- a/test/ActiveLogin.Authentication.BankId.Api.Test/BankIdApiClient_Tests.cs
+++ b/test/ActiveLogin.Authentication.BankId.Api.Test/BankIdApiClient_Tests.cs
@@ -140,6 +140,23 @@ namespace ActiveLogin.Authentication.BankId.Api.Test
         }
 
         [Fact]
+        public async Task AuthAsync_WithAuthRequest__ShouldHaveUserData()
+        {
+            //Arrange
+            byte[] userNonVisibleData = Encoding.ASCII.GetBytes("Hello");
+            string asBase64 = Convert.ToBase64String(userNonVisibleData);
+
+            //Act
+            await _bankIdApiClient.AuthAsync(new AuthRequest("1.1.1.1", null, null, "Hello", userNonVisibleData, "simpleMarkdownV1"));
+
+            //Assert
+            var request = _messageHandlerMock.GetFirstArgumentOfFirstInvocation<HttpMessageHandler, HttpRequestMessage>();
+            var contentString = await request.Content.ReadAsStringAsync();
+
+            Assert.Equal("{\"endUserIp\":\"1.1.1.1\",\"requirement\":{},\"userNonVisibleData\":\"" + asBase64 + "\",\"userVisibleData\":\"" + asBase64 + "\",\"userVisibleDataFormat\":\"simpleMarkdownV1\"}", contentString);
+        }
+
+        [Fact]
         public async Task SignAsync_WithSignRequest__ShouldPostToBankIdSign_WithJsonPayload()
         {
             // Arrange


### PR DESCRIPTION
This PR fixes #328 .

High level overview of this PR:

- [x] Added userVisibleData, userNonVisibleData and userVisibleDataFormat to Auth request
- [x] Possible to add static data on startup
- [x] Added tests to test functionality

These things have been implemented (when relevant):

- [x] Code written
- [x] Test added
- [x] Documentation updated / written
