### PR TITLE
Bump BankID API version to 5.1 in events

### DIFF
--- a/src/ActiveLogin.Authentication.BankId.Api/ActiveLogin.Authentication.BankId.Api.csproj
+++ b/src/ActiveLogin.Authentication.BankId.Api/ActiveLogin.Authentication.BankId.Api.csproj
@@ -11,7 +11,7 @@
         <AssemblyName>ActiveLogin.Authentication.BankId.Api</AssemblyName>
         <PackageId>ActiveLogin.Authentication.BankId.Api</PackageId>
 
-        <VersionPrefix>5.0.0</VersionPrefix>
+        <VersionPrefix>5.0.1</VersionPrefix>
         <!--<VersionSuffix>rc-2</VersionSuffix>-->
         <AssemblyVersion>5.0.0.0</AssemblyVersion>
         <FileVersion Condition="'$(BUILD_BUILDNUMBER)' == ''">$(VersionPrefix).0</FileVersion>

--- a/src/ActiveLogin.Authentication.BankId.Api/BankIdUrls.cs
+++ b/src/ActiveLogin.Authentication.BankId.Api/BankIdUrls.cs
@@ -7,14 +7,16 @@ namespace ActiveLogin.Authentication.BankId.Api
     /// </summary>
     public static class BankIdUrls
     {
+        public const string BankIdApiVersion = "5.1";
+
         /// <summary>
         /// Base url for production API. Needs to be used in conjunction with a production certificate.
         /// </summary>
-        public static readonly Uri ProductionApiBaseUrl = new Uri("https://appapi2.bankid.com/rp/v5.1/");
+        public static readonly Uri ProductionApiBaseUrl = new Uri($"https://appapi2.bankid.com/rp/v{BankIdApiVersion}/");
 
         /// <summary>
         /// Base url for test API. Needs to be used in conjunction with the test certificate.
         /// </summary>
-        public static readonly Uri TestApiBaseUrl = new Uri("https://appapi2.test.bankid.com/rp/v5.1/");
+        public static readonly Uri TestApiBaseUrl = new Uri($"https://appapi2.test.bankid.com/rp/v{BankIdApiVersion}/");
     }
 }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore.Azure/ActiveLogin.Authentication.BankId.AspNetCore.Azure.csproj
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore.Azure/ActiveLogin.Authentication.BankId.AspNetCore.Azure.csproj
@@ -11,7 +11,7 @@
         <AssemblyName>ActiveLogin.Authentication.BankId.AspNetCore.Azure</AssemblyName>
         <PackageId>ActiveLogin.Authentication.BankId.AspNetCore.Azure</PackageId>
 
-        <VersionPrefix>5.0.0</VersionPrefix>
+        <VersionPrefix>5.0.1</VersionPrefix>
         <!--<VersionSuffix>rc-2</VersionSuffix>-->
         <AssemblyVersion>5.0.0.0</AssemblyVersion>
         <FileVersion Condition="'$(BUILD_BUILDNUMBER)' == ''">$(VersionPrefix).0</FileVersion>

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore.AzureMonitor/ActiveLogin.Authentication.BankId.AspNetCore.AzureMonitor.csproj
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore.AzureMonitor/ActiveLogin.Authentication.BankId.AspNetCore.AzureMonitor.csproj
@@ -11,7 +11,7 @@
         <AssemblyName>ActiveLogin.Authentication.BankId.AspNetCore.AzureMonitor</AssemblyName>
         <PackageId>ActiveLogin.Authentication.BankId.AspNetCore.AzureMonitor</PackageId>
 
-        <VersionPrefix>5.0.0</VersionPrefix>
+        <VersionPrefix>5.0.1</VersionPrefix>
         <!--<VersionSuffix>rc-2</VersionSuffix>-->
         <AssemblyVersion>5.0.0.0</AssemblyVersion>
         <FileVersion Condition="'$(BUILD_BUILDNUMBER)' == ''">$(VersionPrefix).0</FileVersion>

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore.QRCoder/ActiveLogin.Authentication.BankId.AspNetCore.QRCoder.csproj
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore.QRCoder/ActiveLogin.Authentication.BankId.AspNetCore.QRCoder.csproj
@@ -12,7 +12,7 @@
         <PackageId>ActiveLogin.Authentication.BankId.AspNetCore.QRCoder</PackageId>
         <RootNamespace>ActiveLogin.Authentication.BankId.AspNetCore.QrCoder</RootNamespace>
 
-        <VersionPrefix>5.0.0</VersionPrefix>
+        <VersionPrefix>5.0.1</VersionPrefix>
         <!--<VersionSuffix>rc-2</VersionSuffix>-->
         <AssemblyVersion>5.0.0.0</AssemblyVersion>
         <FileVersion Condition="'$(BUILD_BUILDNUMBER)' == ''">$(VersionPrefix).0</FileVersion>

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore.UAParser/ActiveLogin.Authentication.BankId.AspNetCore.UAParser.csproj
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore.UAParser/ActiveLogin.Authentication.BankId.AspNetCore.UAParser.csproj
@@ -12,7 +12,7 @@
         <PackageId>ActiveLogin.Authentication.BankId.AspNetCore.UAParser</PackageId>
         <RootNamespace>ActiveLogin.Authentication.BankId.AspNetCore.UaParser</RootNamespace>
 
-        <VersionPrefix>5.0.0</VersionPrefix>
+        <VersionPrefix>5.0.1</VersionPrefix>
         <!--<VersionSuffix>rc-2</VersionSuffix>-->
         <AssemblyVersion>5.0.0.0</AssemblyVersion>
         <FileVersion Condition="'$(BUILD_BUILDNUMBER)' == ''">$(VersionPrefix).0</FileVersion>

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/ActiveLogin.Authentication.BankId.AspNetCore.csproj
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/ActiveLogin.Authentication.BankId.AspNetCore.csproj
@@ -13,7 +13,7 @@
         <AssemblyName>ActiveLogin.Authentication.BankId.AspNetCore</AssemblyName>
         <PackageId>ActiveLogin.Authentication.BankId.AspNetCore</PackageId>
 
-        <VersionPrefix>5.0.0</VersionPrefix>
+        <VersionPrefix>5.0.1</VersionPrefix>
         <!--<VersionSuffix>rc-2</VersionSuffix>-->
         <AssemblyVersion>5.0.0.0</AssemblyVersion>
         <FileVersion Condition="'$(BUILD_BUILDNUMBER)' == ''">$(VersionPrefix).0</FileVersion>

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdConstants.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdConstants.cs
@@ -1,5 +1,7 @@
 using System.Text.Json;
 
+using ActiveLogin.Authentication.BankId.Api;
+
 namespace ActiveLogin.Authentication.BankId.AspNetCore
 {
     public static class BankIdConstants
@@ -10,7 +12,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore
 
         internal const string InvalidReturnUrlErrorMessage = "Invalid returnUrl. Needs to be a local url.";
 
-        internal const string BankIdApiVersion = "5.1";
+        internal const string BankIdApiVersion = BankIdUrls.BankIdApiVersion;
 
         internal static readonly JsonSerializerOptions JsonSerializerOptions = new JsonSerializerOptions
         {

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdConstants.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdConstants.cs
@@ -10,7 +10,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore
 
         internal const string InvalidReturnUrlErrorMessage = "Invalid returnUrl. Needs to be a local url.";
 
-        internal const string BankIdApiVersion = "5.0";
+        internal const string BankIdApiVersion = "5.1";
 
         internal static readonly JsonSerializerOptions JsonSerializerOptions = new JsonSerializerOptions
         {


### PR DESCRIPTION
Set the correct BankID API version in the BankIdActiveLoginContext which is used in triggered events.

Also made sure that the mismatch should be harder to accomplish in the future by making is a constant in the BankIdUrls class.