### PR TITLE
Decoupled JSON serialization from system defined serialization

### DIFF
--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/ActiveLogin/Controllers/BankIdUiApiControllerBase.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/ActiveLogin/Controllers/BankIdUiApiControllerBase.cs
@@ -1,3 +1,4 @@
+using System.Net.Mime;
 using System.Text.Json;
 
 using ActiveLogin.Authentication.BankId.Api;
@@ -160,7 +161,7 @@ public abstract class BankIdUiApiControllerBase : ControllerBase
     {
         return new ContentResult
         {
-            ContentType = "application/json",
+            ContentType = MediaTypeNames.Application.Json,
             StatusCode = StatusCodes.Status200OK,
             Content = JsonSerializer.Serialize(model, JsonSerializerOptions)
         };
@@ -170,7 +171,7 @@ public abstract class BankIdUiApiControllerBase : ControllerBase
     {
         return new ContentResult
         {
-            ContentType = "application/json",
+            ContentType = MediaTypeNames.Application.Json,
             StatusCode = StatusCodes.Status400BadRequest,
             Content = JsonSerializer.Serialize(model, JsonSerializerOptions)
         };

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/ActiveLogin/Controllers/BankIdUiApiControllerBase.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/ActiveLogin/Controllers/BankIdUiApiControllerBase.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+
 using ActiveLogin.Authentication.BankId.Api;
 using ActiveLogin.Authentication.BankId.Api.Models;
 using ActiveLogin.Authentication.BankId.Api.UserMessage;
@@ -16,6 +18,8 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.Areas.ActiveLogin.Control
 [NonController]
 public abstract class BankIdUiApiControllerBase : ControllerBase
 {
+    private static JsonSerializerOptions JsonSerializerOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+
     protected readonly IBankIdFlowService BankIdFlowService;
     protected readonly IBankIdUiOrderRefProtector OrderRefProtector;
     protected readonly IBankIdQrStartStateProtector QrStartStateProtector;
@@ -154,17 +158,21 @@ public abstract class BankIdUiApiControllerBase : ControllerBase
 
     protected static ActionResult OkJsonResult(object model)
     {
-        return new JsonResult(model, BankIdConstants.JsonSerializerOptions)
+        return new ContentResult
         {
-            StatusCode = StatusCodes.Status200OK
+            ContentType = "application/json",
+            StatusCode = StatusCodes.Status200OK,
+            Content = JsonSerializer.Serialize(model, JsonSerializerOptions)
         };
     }
 
     protected static ActionResult BadRequestJsonResult(object model)
     {
-        return new JsonResult(model, BankIdConstants.JsonSerializerOptions)
+        return new ContentResult
         {
-            StatusCode = StatusCodes.Status400BadRequest
+            ContentType = "application/json",
+            StatusCode = StatusCodes.Status400BadRequest,
+            Content = JsonSerializer.Serialize(model, JsonSerializerOptions)
         };
     }
 }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdConstants.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdConstants.cs
@@ -14,11 +14,6 @@ internal static class BankIdConstants
 
     public const string LocalizationResourcesPath = "Resources";
 
-    internal static readonly JsonSerializerOptions JsonSerializerOptions = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-    };
-
     public static class AuthenticationPropertiesKeys
     {
         public const string CancelReturnUrl = "cancelReturnUrl";


### PR DESCRIPTION
This PR fixes #373.

High level overview of this PR:

- [X] Decouples JSON serialization from built in settings to allow users to use JSON.NET

These things have been implemented (when relevant):

- [X] Code written
- [-] Test added
- [-] Documentation updated / written
