### PR TITLE
Add client side retry logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Free to use, [commercial support and training](#support--training) is available 
 - :id: Supports BankID Auth (API, Flow and UI)
 - :pencil: Supports BankID Sign (API, Flow and UI)
 - :relaxed: Supports BankID Verify digital ID card (API)
-- :penguin: Cross platform: Targets .NET Standard 2.0 and .NET 7
+- :penguin: Cross platform: Targets .NET Standard 2.0 and .NET 8
 - :six: Built on V6.0 (the latest) BankID JSON API
 - :checkered_flag: Supports BankID animated QR code (Secure start)
 - :cloud: Designed with Microsoft Azure in mind (KeyVault, Monitor, Application Insights, AD B2C etc.)

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/ActiveLogin.Authentication.BankId.AspNetCore.csproj
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/ActiveLogin.Authentication.BankId.AspNetCore.csproj
@@ -73,7 +73,7 @@
         <TypeScriptNoImplicitAny>true</TypeScriptNoImplicitAny>
         <TypeScriptNoEmitOnError>true</TypeScriptNoEmitOnError>
         <TypeScriptRemoveComments>false</TypeScriptRemoveComments>
-        <TypeScriptSourceMap>true</TypeScriptSourceMap>
+        <TypeScriptSourceMap>false</TypeScriptSourceMap>
         <TypeScriptTarget>es2018</TypeScriptTarget>
         <TypeScriptLib>dom,es2018</TypeScriptLib>
         <TypeScriptModuleKind>None</TypeScriptModuleKind>

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Client/activelogin-main.ts
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Client/activelogin-main.ts
@@ -22,7 +22,8 @@ interface IBankIdUiScriptInitState {
 }
 
 function activeloginInit(configuration: IBankIdUiScriptConfiguration, initState: IBankIdUiScriptInitState) {
-    const fetchRetryRetryDelayMs: number = 1000;
+    const fetchRetryCountDefault: number = 3;
+    const fetchRetryDelayMs: number = 1000;
 
     // Pre check
 
@@ -128,7 +129,7 @@ function activeloginInit(configuration: IBankIdUiScriptConfiguration, initState:
             {
                 "returnUrl": returnUrl,
                 "uiOptions": protectedUiOptions
-            }, 3)
+            }, fetchRetryCountDefault)
             .then(data => {
                 if (data.isAutoLaunch) {
                     if (!data.checkStatus) {
@@ -183,7 +184,7 @@ function activeloginInit(configuration: IBankIdUiScriptConfiguration, initState:
                 "returnUrl": returnUrl,
                 "uiOptions": protectedUiOptions,
                 "autoStartAttempts": autoStartAttempts
-            }, 3)
+            }, fetchRetryCountDefault)
             .then(data => {
                 if (data.retryLogin) {
                     autoStartAttempts++;
@@ -233,7 +234,7 @@ function activeloginInit(configuration: IBankIdUiScriptConfiguration, initState:
             requestVerificationToken,
             {
                 "qrStartState": qrStartState
-            }, 3)
+            }, fetchRetryCountDefault)
             .then(data => {
                 if (!!data.qrCodeAsBase64) {
                     qrLastRefreshTimestamp = new Date();
@@ -299,7 +300,7 @@ function activeloginInit(configuration: IBankIdUiScriptConfiguration, initState:
             })
             .catch(error => {
                 if (retryCount > 0) {
-                    return delay(fetchRetryRetryDelayMs).then(() => {
+                    return delay(fetchRetryDelayMs).then(() => {
                         return postJson(url, requestVerificationToken, data, retryCount - 1);
                     });
                 }
@@ -308,7 +309,7 @@ function activeloginInit(configuration: IBankIdUiScriptConfiguration, initState:
             })
             .then(response => {
                 if (!response.ok && retryCount > 0) {
-                    return delay(fetchRetryRetryDelayMs).then(() => {
+                    return delay(fetchRetryDelayMs).then(() => {
                         return postJson(url, requestVerificationToken, data, retryCount - 1)
                     });
                 }


### PR DESCRIPTION
This PR fixes #433.

Adds 3 retries (with 1000ms delay inbetween) for `initialize`, `checkStatus` and `refreshQrCode`.