### PR TITLE
AddCustomBrowserByUserAgent will always override regardless of device

### DIFF
--- a/BREAKINGCHANGES.md
+++ b/BREAKINGCHANGES.md
@@ -30,8 +30,6 @@ We have renamed these things as a result of that:
 * `AddCustomAppCallback` becomes `AddCustomBrowser`
 * `AddCustomAppCallbackByUserAgent` becomes `AddCustomBrowserByUserAgent`
 
-Also, the return URL is now only applied on iOS, as the expected behaviour on Android is to apply null so that Android automatically can return to the previous app.
-
 ### Upgrade to .NET 7
 
 We now require .NET 8 - so this requires you to upgrade your website that uses Active Login.

--- a/docs/articles/bankid.md
+++ b/docs/articles/bankid.md
@@ -1081,9 +1081,9 @@ The default implementation provided in `ActiveLogin.Authentication.BankId.AspNet
 
 If you want to support your custom app, or a third party app (like the built in browsers in Instagram, Facebook etc.) we've made it simple to support those scenarios by allowing you to specify a custom browser config.
 
-The most common scenario is that you will set the schema for the app as return URL if you detect a specific User Agent, so for that scenario we've made an extension method.
+The most common scenario is that you will set the schema for the app as return URL if you detect a specific User Agent.
 
-Note: The return url will onlt by applied on iOS, as Android will return the user to the app automatically.
+The `AddCustomBrowserByUserAgent` extension method is a shorthand for adding a custom browser config for a specific user agent that overrides the return url regardless of device.
 
 In the sample below we add support for Instagram and Facebook:
 

--- a/src/ActiveLogin.Authentication.BankId.Core/Launcher/BankIdLauncher.cs
+++ b/src/ActiveLogin.Authentication.BankId.Core/Launcher/BankIdLauncher.cs
@@ -136,6 +136,12 @@ internal class BankIdLauncher : IBankIdLauncher
 
     private static string GetRedirectUrl(BankIdSupportedDevice device, LaunchUrlRequest request, BankIdLauncherCustomBrowserConfig? customBrowserConfig)
     {
+        // Allow for easy override of callback url
+        if (customBrowserConfig != null && customBrowserConfig.ReturnUrl != null)
+        {
+            return customBrowserConfig.ReturnUrl;
+        }
+
         // Only use redirect url for iOS as recommended in BankID Guidelines 3.1.2
         return device.DeviceOs == BankIdSupportedDeviceOs.Ios
             ? GetIOsBrowserSpecificRedirectUrl(device, request.RedirectUrl, customBrowserConfig)
@@ -144,12 +150,6 @@ internal class BankIdLauncher : IBankIdLauncher
 
     private static string GetIOsBrowserSpecificRedirectUrl(BankIdSupportedDevice device, string redirectUrl, BankIdLauncherCustomBrowserConfig? customBrowserConfig)
     {
-        // Allow for easy override of callback url
-        if (customBrowserConfig != null && customBrowserConfig.IosReturnUrl != null)
-        {
-            return customBrowserConfig.IosReturnUrl;
-        }
-
         // If it is a third party browser, don't specify the return URL, just the browser scheme.
         // This will launch the browser with the last page used (the Active Login status page).
         // If a URL is specified these browsers will open that URL in a new tab and we will lose context.

--- a/src/ActiveLogin.Authentication.BankId.Core/Launcher/BankIdLauncherCustomBrowserConfig.cs
+++ b/src/ActiveLogin.Authentication.BankId.Core/Launcher/BankIdLauncherCustomBrowserConfig.cs
@@ -2,9 +2,9 @@ namespace ActiveLogin.Authentication.BankId.Core.Launcher;
 
 public class BankIdLauncherCustomBrowserConfig
 {
-    public BankIdLauncherCustomBrowserConfig(string? iosReturnUrl, BrowserReloadBehaviourOnReturnFromBankIdApp browserReloadBehaviourOnReturnFromBankIdApp = BrowserReloadBehaviourOnReturnFromBankIdApp.Default, BrowserMightRequireUserInteractionToLaunch browserMightRequireUserInteractionToLaunch = BrowserMightRequireUserInteractionToLaunch.Default)
+    public BankIdLauncherCustomBrowserConfig(string? returnUrl, BrowserReloadBehaviourOnReturnFromBankIdApp browserReloadBehaviourOnReturnFromBankIdApp = BrowserReloadBehaviourOnReturnFromBankIdApp.Default, BrowserMightRequireUserInteractionToLaunch browserMightRequireUserInteractionToLaunch = BrowserMightRequireUserInteractionToLaunch.Default)
     {
-        IosReturnUrl = iosReturnUrl;
+        ReturnUrl = returnUrl;
         BrowserReloadBehaviourOnReturnFromBankIdApp = browserReloadBehaviourOnReturnFromBankIdApp;
         BrowserMightRequireUserInteractionToLaunch = browserMightRequireUserInteractionToLaunch;
     }
@@ -15,7 +15,7 @@ public class BankIdLauncherCustomBrowserConfig
     /// Set to empty string to not launch any URL, and instead the BanKID app will ask the user to open the last app.
     /// This will only be applied to iOS as Android automatically launches the previous app.
     /// </summary>
-    public string? IosReturnUrl { get; set; }
+    public string? ReturnUrl { get; set; }
 
     /// <summary>
     /// The reload behaviour of the browser when returning from the BankID app.

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,7 +15,7 @@
         <PackageId>$(AssemblyName)</PackageId>
 
         <VersionPrefix>8.0.0</VersionPrefix>
-        <VersionSuffix>alpha-1</VersionSuffix>
+        <VersionSuffix>beta-1</VersionSuffix>
         <AssemblyVersion>8.0.0.0</AssemblyVersion>
         <FileVersion Condition="'$(BUILD_BUILDNUMBER)' == ''">$(VersionPrefix).0</FileVersion>
         <FileVersion Condition="'$(BUILD_BUILDNUMBER)' != ''">$(VersionPrefix).$(BUILD_BUILDNUMBER)</FileVersion>


### PR DESCRIPTION
Move the custom redirect part of the code to be able to override redirects even if it isn't an iphone and rename the return url from iosReturnUrl to ReturnUrl. 

This makes it possible for TWA (wrapped PWA) to use a user agent without faking being anything else.

This PR fixes #442 .
