### PR TITLE
Implement phone API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Active Login is not a product created by BankID. It is an unofficial project tha
 
 - :id: Supports BankID Auth (API, Flow and UI)
 - :pencil: Supports BankID Sign (API, Flow and UI)
+- :phone::id: Supports BankID Phone Auth (API)
+- :phone::pencil: Supports BankID Phone Sign (API)
 - :relaxed: Supports BankID Verify digital ID card (API)
 - :penguin: Cross platform: Targets .NET Standard 2.0 and .NET 8
 - :six: Built on V6.0 (the latest) BankID JSON API

--- a/docs/articles/bankid.md
+++ b/docs/articles/bankid.md
@@ -1238,6 +1238,8 @@ public class BankIdAppApiClient : IBankIdAppApiClient
 {
     public Task<AuthResponse> AuthAsync(AuthRequest request) { ... }
     public Task<SignResponse> SignAsync(SignRequest request) { ... }
+    public Task<PhoneAuthResponse> PhoneAuthAsync(PhoneAuthRequest request) { ... }
+    public Task<PhoneSignResponse> PhoneSignAsync(PhoneSignRequest request) { ... }
     public Task<CollectResponse> CollectAsync(CollectRequest request) { ... }
     public Task<CancelResponse> CancelAsync(CancelRequest request) { ... }
 }

--- a/src/ActiveLogin.Authentication.BankId.Api/ActiveLogin.Authentication.BankId.Api.csproj
+++ b/src/ActiveLogin.Authentication.BankId.Api/ActiveLogin.Authentication.BankId.Api.csproj
@@ -17,10 +17,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="ActiveLogin.Identity.Swedish" Version="3.0.0" />
-    </ItemGroup>
-
-    <ItemGroup>
         <None Include="..\..\docs\images\active-login-logo-fingerprint-blue-v2-256x256.png" Pack="True" PackagePath="icon.png" />
         <None Include="..\..\LICENSE.md" Pack="True" PackagePath="LICENSE.md" />
         <None Include="README.md" Pack="True" PackagePath="README.md" />

--- a/src/ActiveLogin.Authentication.BankId.Api/ActiveLogin.Authentication.BankId.Api.csproj
+++ b/src/ActiveLogin.Authentication.BankId.Api/ActiveLogin.Authentication.BankId.Api.csproj
@@ -17,6 +17,10 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="ActiveLogin.Identity.Swedish" Version="3.0.0" />
+    </ItemGroup>
+
+    <ItemGroup>
         <None Include="..\..\docs\images\active-login-logo-fingerprint-blue-v2-256x256.png" Pack="True" PackagePath="icon.png" />
         <None Include="..\..\LICENSE.md" Pack="True" PackagePath="LICENSE.md" />
         <None Include="README.md" Pack="True" PackagePath="README.md" />

--- a/src/ActiveLogin.Authentication.BankId.Api/BankIdApiConverters.cs
+++ b/src/ActiveLogin.Authentication.BankId.Api/BankIdApiConverters.cs
@@ -53,11 +53,11 @@ public class BankIdApiConverters
     }
 
     /// <summary>
-    /// Parse collect call initiator from string.
+    /// Parse call initiator from string.
     /// </summary>
-    public static CollectCallInitiator ParseCollectCallInitiator(string? callInitiator)
+    public static CallInitiator ParseCallInitiator(string? callInitiator)
     {
-        return Enum.TryParse<CollectCallInitiator>(callInitiator, true, out var parsedStatus) ? parsedStatus : CollectCallInitiator.Unknown;
+        return Enum.TryParse<CallInitiator>(callInitiator, true, out var parsedStatus) ? parsedStatus : CallInitiator.Unknown;
     }
 
     /// <summary>

--- a/src/ActiveLogin.Authentication.BankId.Api/BankIdAppApiClient.cs
+++ b/src/ActiveLogin.Authentication.BankId.Api/BankIdAppApiClient.cs
@@ -28,12 +28,30 @@ public class BankIdAppApiClient : IBankIdAppApiClient
     }
 
     /// <summary>
-    /// Initiates an signing order. Use the collect method to query the status of the order.
+    /// Initiates a signing order. Use the collect method to query the status of the order.
     /// </summary>
     /// <returns>If the request is successful, the OrderRef and AutoStartToken is returned.</returns>
     public Task<SignResponse> SignAsync(SignRequest request)
     {
         return _httpClient.PostAsync<SignRequest, SignResponse>("sign", request);
+    }
+
+    /// <summary>
+    /// Initiates a phone authentication order. Use the collect method to query the status of the order.
+    /// </summary>
+    /// <returns>If the request is successful, the OrderRef is returned.</returns>
+    public Task<PhoneAuthResponse> PhoneAuthAsync(PhoneAuthRequest request)
+    {
+        return _httpClient.PostAsync<PhoneAuthRequest, PhoneAuthResponse>("phone/auth", request);
+    }
+
+    /// <summary>
+    /// Initiates a phone signing order. Use the collect method to query the status of the order.
+    /// </summary>
+    /// <returns>If the request is successful, the OrderRef is returned.</returns>
+    public Task<PhoneSignResponse> PhoneSignAsync(PhoneSignRequest request)
+    {
+        return _httpClient.PostAsync<PhoneSignRequest, PhoneSignResponse>("phone/sign", request);
     }
 
     /// <summary>

--- a/src/ActiveLogin.Authentication.BankId.Api/BankIdAppApiClientExtensions.cs
+++ b/src/ActiveLogin.Authentication.BankId.Api/BankIdAppApiClientExtensions.cs
@@ -110,6 +110,100 @@ public static class BankIdAppApiClientExtensions
             userNonVisibleData: userNonVisibleData));
     }
 
+    /// <summary></summary>
+    /// <param name="appApiClient">The <see cref="IBankIdAppApiClient"/> instance.</param>
+    /// <param name="personalIdentityNumber">
+    /// The personal number of the user. String. 12 digits.
+    /// </param>
+    /// <param name="callInitiator">
+    /// Indicate if the user or the RP initiated the phone call. user: user called the RP. RP: RP called the user.
+    /// </param>
+    /// <param name="requirement">Requirements on how the phone auth or phone sign order must be performed.</param>
+    /// <param name="userVisibleData">
+    /// The text to be displayed and signed. The text can be formatted using CR, LF and CRLF for new lines.
+    /// </param>
+    /// <param name="userNonVisibleData">
+    /// Data not displayed to the user.
+    /// </param>
+    /// <param name="userVisibleDataFormat">
+    /// If present, and set to "simpleMarkdownV1", this parameter indicates that userVisibleData holds formatting characters which, if used correctly, will make the text displayed with the user nicer to look at.
+    /// For further information of formatting options, please study the document Guidelines for Formatted Text.
+    /// </param>
+    public static Task<PhoneAuthResponse> PhoneAuthAsync(
+        this IBankIdAppApiClient appApiClient,
+        string personalIdentityNumber,
+        CallInitiator callInitiator,
+        PhoneRequirement? requirement = null,
+        string? userVisibleData = null,
+        byte[]? userNonVisibleData = null,
+        string? userVisibleDataFormat = null)
+    {
+        return appApiClient.PhoneAuthAsync(new(
+            personalIdentityNumber,
+            callInitiator,
+            userVisibleData: userVisibleData,
+            userNonVisibleData: userNonVisibleData,
+            requirement: requirement,
+            userVisibleDataFormat: userVisibleDataFormat));
+    }
+
+    /// <summary></summary>
+    /// <param name="appApiClient">The <see cref="IBankIdAppApiClient"/> instance.</param>
+    /// <param name="personalIdentityNumber">
+    /// The personal number of the user. String. 12 digits.
+    /// </param>
+    /// <param name="callInitiator">
+    /// Indicate if the user or the RP initiated the phone call. user: user called the RP. RP: RP called the user.
+    /// </param>
+    /// <returns>If the request is successful, the OrderRef is returned.</returns>
+    public static Task<PhoneAuthResponse> PhoneAuthAsync(this IBankIdAppApiClient appApiClient,
+        string personalIdentityNumber, CallInitiator callInitiator)
+    {
+        return appApiClient.PhoneAuthAsync(new PhoneAuthRequest(personalIdentityNumber, callInitiator));
+    }
+
+    /// <summary></summary>
+    /// <param name="appApiClient">The <see cref="IBankIdAppApiClient"/> instance.</param>
+    /// <param name="personalIdentityNumber">
+    /// The personal number of the user. String. 12 digits.
+    /// </param>
+    /// <param name="callInitiator">
+    /// Indicate if the user or the RP initiated the phone call. user: user called the RP. RP: RP called the user.
+    /// </param>
+    /// <param name="userVisibleData">
+    /// The text to be displayed and signed. The text can be formatted using CR, LF and CRLF for new lines.
+    /// </param>
+    public static Task<PhoneSignResponse> PhoneSignAsync(this IBankIdAppApiClient appApiClient,
+        string personalIdentityNumber, CallInitiator callInitiator, string userVisibleData)
+    {
+        return appApiClient.PhoneSignAsync(new(
+            personalIdentityNumber,
+            callInitiator,
+            userVisibleData));
+    }
+
+    /// <summary></summary>
+    /// <param name="appApiClient">The <see cref="IBankIdAppApiClient"/> instance.</param>
+    /// <param name="personalIdentityNumber">
+    /// The personal number of the user. String. 12 digits.
+    /// </param>
+    /// <param name="callInitiator">
+    /// Indicate if the user or the RP initiated the phone call. user: user called the RP. RP: RP called the user.
+    /// </param>
+    /// <param name="userVisibleData">
+    /// The text to be displayed and signed. The text can be formatted using CR, LF and CRLF for new lines.
+    /// </param>
+    /// <param name="userNonVisibleData">
+    /// Data not displayed to the user.
+    /// </param>
+    /// <returns>If the request is successful, the OrderRef is returned.</returns>
+    public static Task<PhoneSignResponse> PhoneSignAsync(this IBankIdAppApiClient appApiClient,
+        string personalIdentityNumber, CallInitiator callInitiator, string userVisibleData, byte[] userNonVisibleData)
+    {
+        return appApiClient.PhoneSignAsync(new PhoneSignRequest(personalIdentityNumber, callInitiator, userVisibleData,
+            userNonVisibleData));
+    }
+
     /// <summary>
     /// Collects the result of a sign or auth order using the OrderRef as reference.
     /// RP should keep on calling collect every two seconds as long as status indicates pending.

--- a/src/ActiveLogin.Authentication.BankId.Api/IBankIdAppApiClient.cs
+++ b/src/ActiveLogin.Authentication.BankId.Api/IBankIdAppApiClient.cs
@@ -14,10 +14,22 @@ public interface IBankIdAppApiClient
     Task<AuthResponse> AuthAsync(AuthRequest request);
 
     /// <summary>
-    /// Initiates an signing order. Use the collect method to query the status of the order.
+    /// Initiates a signing order. Use the collect method to query the status of the order.
     /// </summary>
     /// <returns>If the request is successful, the OrderRef and AutoStartToken is returned.</returns>
     Task<SignResponse> SignAsync(SignRequest request);
+
+    /// <summary>
+    /// Initiates a phone authentication order. Use the collect method to query the status of the order.
+    /// </summary>
+    /// <returns>If the request is successful, the OrderRef is returned.</returns>
+    Task<PhoneAuthResponse> PhoneAuthAsync(PhoneAuthRequest request);
+
+    /// <summary>
+    /// Initiates a phone signing order. Use the collect method to query the status of the order.
+    /// </summary>
+    /// <returns>If the request is successful, the OrderRef is returned.</returns>
+    Task<PhoneSignResponse> PhoneSignAsync(PhoneSignRequest request);
 
     /// <summary>
     /// Collects the result of a sign or auth order using the OrderRef as reference.

--- a/src/ActiveLogin.Authentication.BankId.Api/Models/CallInitiator.cs
+++ b/src/ActiveLogin.Authentication.BankId.Api/Models/CallInitiator.cs
@@ -3,7 +3,7 @@ namespace ActiveLogin.Authentication.BankId.Api.Models;
 /// <summary>
 /// Possible values of call initiator for phone authentication.
 /// </summary>
-public enum CollectCallInitiator
+public enum CallInitiator
 {
     /// <summary>
     /// Unknown or new call initiator.

--- a/src/ActiveLogin.Authentication.BankId.Api/Models/CollectResponseExtensions.cs
+++ b/src/ActiveLogin.Authentication.BankId.Api/Models/CollectResponseExtensions.cs
@@ -25,8 +25,8 @@ public static class CollectResponseExtensions
     /// Indicates whether RP or user initiated a phone/auth, if phone authentication. 
     /// </summary>
     /// <remarks>Only present for phone authentication.</remarks>
-    public static CollectCallInitiator GetCollectCallInitiator(this CollectResponse collectResponse)
+    public static CallInitiator GetCollectCallInitiator(this CollectResponse collectResponse)
     {
-        return BankIdApiConverters.ParseCollectCallInitiator(collectResponse.CallInitiator);
+        return BankIdApiConverters.ParseCallInitiator(collectResponse.CallInitiator);
     }
 }

--- a/src/ActiveLogin.Authentication.BankId.Api/Models/PhoneAuthRequest.cs
+++ b/src/ActiveLogin.Authentication.BankId.Api/Models/PhoneAuthRequest.cs
@@ -1,0 +1,42 @@
+namespace ActiveLogin.Authentication.BankId.Api.Models;
+
+/// <summary>
+/// Phone auth request parameters.
+/// </summary>
+public class PhoneAuthRequest : PhoneRequest
+{
+    /// <summary></summary>
+    /// <param name="personalIdentityNumber">
+    /// The personal number of the user. String. 12 digits.
+    /// </param>
+    /// <param name="callInitiator">
+    /// Indicate if the user or the RP initiated the phone call. user: user called the RP. RP: RP called the user.
+    /// </param>
+    /// <param name="requirement">Requirements on how the phone auth or phone sign order must be performed.</param>
+    /// <param name="userVisibleData">
+    /// The text to be displayed and signed. The text can be formatted using CR, LF and CRLF for new lines.
+    /// </param>
+    /// <param name="userNonVisibleData">
+    /// Data not displayed to the user.
+    /// </param>
+    /// <param name="userVisibleDataFormat">
+    /// If present, and set to "simpleMarkdownV1", this parameter indicates that userVisibleData holds formatting characters which, if used correctly, will make the text displayed with the user nicer to look at.
+    /// For further information of formatting options, please study the document Guidelines for Formatted Text.
+    /// </param>
+    public PhoneAuthRequest(
+        string personalIdentityNumber,
+        CallInitiator callInitiator,
+        PhoneRequirement? requirement = null,
+        string? userVisibleData = null,
+        byte[]? userNonVisibleData = null,
+        string? userVisibleDataFormat = null)
+        : base(
+            personalIdentityNumber,
+            callInitiator,
+            userVisibleData: userVisibleData,
+            userNonVisibleData: userNonVisibleData,
+            requirement: requirement,
+            userVisibleDataFormat: userVisibleDataFormat)
+    {
+    }
+}

--- a/src/ActiveLogin.Authentication.BankId.Api/Models/PhoneAuthResponse.cs
+++ b/src/ActiveLogin.Authentication.BankId.Api/Models/PhoneAuthResponse.cs
@@ -1,0 +1,9 @@
+namespace ActiveLogin.Authentication.BankId.Api.Models;
+
+public class PhoneAuthResponse : PhoneResponse
+{
+    public PhoneAuthResponse(string orderRef)
+        : base(orderRef)
+    {
+    }
+}

--- a/src/ActiveLogin.Authentication.BankId.Api/Models/PhoneRequest.cs
+++ b/src/ActiveLogin.Authentication.BankId.Api/Models/PhoneRequest.cs
@@ -1,0 +1,201 @@
+using System.Text;
+using System.Text.Json.Serialization;
+
+using ActiveLogin.Identity.Swedish;
+
+namespace ActiveLogin.Authentication.BankId.Api.Models;
+public abstract class PhoneRequest
+{
+    /// <summary></summary>
+    /// <param name="personalIdentityNumber">
+    /// The personal number of the user. String. 12 digits.
+    /// </param>
+    /// <param name="callInitiator">
+    /// Indicate if the user or the RP initiated the phone call. user: user called the RP. RP: RP called the user.
+    /// </param>
+    /// <param name="userVisibleData">
+    /// The text to be displayed and signed. The text can be formatted using CR, LF and CRLF for new lines.
+    /// </param>
+    ///
+    public PhoneRequest(string personalIdentityNumber, CallInitiator callInitiator, string userVisibleData)
+        : this(personalIdentityNumber, callInitiator, userVisibleData, null, null, null)
+    {
+    }
+
+    /// <summary></summary>
+    /// <param name="personalIdentityNumber">
+    /// The personal number of the user. String. 12 digits.
+    /// </param>
+    /// <param name="callInitiator">
+    /// Indicate if the user or the RP initiated the phone call. user: user called the RP. RP: RP called the user.
+    /// </param>
+    /// <param name="userVisibleData">
+    /// The text to be displayed and signed. The text can be formatted using CR, LF and CRLF for new lines.
+    /// </param>
+    /// <param name="userNonVisibleData">
+    /// Data not displayed to the user.
+    /// </param>
+    public PhoneRequest(string personalIdentityNumber, CallInitiator callInitiator, string userVisibleData,
+        byte[] userNonVisibleData)
+        : this(personalIdentityNumber, callInitiator, userVisibleData, userNonVisibleData, null, null)
+    {
+    }
+
+    /// <summary></summary>
+    /// <param name="personalIdentityNumber">
+    /// The personal number of the user. String. 12 digits.
+    /// </param>
+    /// <param name="callInitiator">
+    /// Indicate if the user or the RP initiated the phone call. user: user called the RP. RP: RP called the user.
+    /// </param>
+    /// <param name="userVisibleData">
+    /// The text to be displayed and signed. The text can be formatted using CR, LF and CRLF for new lines.
+    /// </param>
+    /// <param name="userVisibleDataFormat">
+    /// If present, and set to "simpleMarkdownV1", this parameter indicates that userVisibleData holds formatting characters which, if used correctly, will make the text displayed with the user nicer to look at.
+    /// For further information of formatting options, please study the document Guidelines for Formatted Text.
+    /// </param>
+    /// <param name="userNonVisibleData">
+    /// Data not displayed to the user.
+    /// </param>
+    public PhoneRequest(string personalIdentityNumber, CallInitiator callInitiator, string userVisibleData,
+        string userVisibleDataFormat, byte[] userNonVisibleData)
+        : this(personalIdentityNumber, callInitiator, userVisibleData, userNonVisibleData, null, userVisibleDataFormat)
+    {
+    }
+
+    /// <summary></summary>
+    /// <param name="personalIdentityNumber">
+    /// The personal number of the user. String. 12 digits.
+    /// </param>
+    /// <param name="callInitiator">
+    /// Indicate if the user or the RP initiated the phone call. user: user called the RP. RP: RP called the user.
+    /// </param>
+    /// <param name="userVisibleData">
+    /// The text to be displayed and signed. The text can be formatted using CR, LF and CRLF for new lines.
+    /// </param>
+    /// <param name="userNonVisibleData">
+    /// Data not displayed to the user.
+    /// </param>
+    /// <param name="requirement">Requirements on how the phone auth or phone sign order must be performed.</param>
+    public PhoneRequest(string personalIdentityNumber, CallInitiator callInitiator, string userVisibleData,
+        byte[]? userNonVisibleData, PhoneRequirement? requirement)
+        : this(personalIdentityNumber, callInitiator, userVisibleData, userNonVisibleData, requirement, null)
+    {
+    }
+
+    /// <summary></summary>
+    /// <param name="personalIdentityNumber">
+    /// The personal number of the user. String. 12 digits.
+    /// </param>
+    /// <param name="callInitiator">
+    /// Indicate if the user or the RP initiated the phone call. user: user called the RP. RP: RP called the user.
+    /// </param>
+    /// <param name="userVisibleData">
+    /// The text to be displayed and signed. The text can be formatted using CR, LF and CRLF for new lines.
+    /// </param>
+    /// <param name="userNonVisibleData">
+    /// Data not displayed to the user.
+    /// </param>
+    /// <param name="requirement">Requirements on how the phone auth or phone sign order must be performed.</param>
+    /// <param name="userVisibleDataFormat">
+    /// If present, and set to "simpleMarkdownV1", this parameter indicates that userVisibleData holds formatting characters which, if used correctly, will make the text displayed with the user nicer to look at.
+    /// For further information of formatting options, please study the document Guidelines for Formatted Text.
+    /// </param>
+    public PhoneRequest(string personalIdentityNumber, CallInitiator callInitiator, string? userVisibleData,
+        byte[]? userNonVisibleData, PhoneRequirement? requirement, string? userVisibleDataFormat)
+    {
+        if(this is PhoneSignRequest && userVisibleData == null)
+        {
+            throw new ArgumentNullException(nameof(userVisibleData));
+        }
+
+        PersonalIdentityNumber = ConvertToPin(personalIdentityNumber).ToString();
+        CallInitiator = ParseCallInitiator(callInitiator);
+        UserVisibleData = ToBase64EncodedString(userVisibleData);
+        UserNonVisibleData = ToBase64EncodedString(userNonVisibleData);
+        Requirement = requirement ?? new PhoneRequirement();
+        UserVisibleDataFormat = userVisibleDataFormat;
+    }
+
+    /// <summary>
+    /// The personal number of the user. String. 12 digits.
+    /// </summary>
+    [JsonPropertyName("personalNumber")]
+    public string PersonalIdentityNumber { get; }
+
+    /// <summary>
+    /// Indicate if the user or the RP initiated the phone call. user: user called the RP. RP: RP called the user.
+    /// </summary>
+    [JsonPropertyName("callInitiator")]
+    public string CallInitiator { get; }
+
+    /// <summary>
+    /// Requirements on how the phone auth or phone sign order must be performed.
+    /// </summary>
+    [JsonPropertyName("requirement"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public PhoneRequirement Requirement { get; }
+
+    /// <summary>
+    /// The text can be formatted using CR, LF and CRLF for new lines.
+    /// The text must be encoded as UTF-8 and then base 64 encoded.
+    /// 1—1 500 characters after base 64encoding.
+    ///
+    /// Scenario sign: The text to be displayed and signed. String. The text can be formatted using CR, LF and CRLF for new lines.
+    ///
+    /// Scenario auth: A text that is displayed to the user during authentication with BankID, with the
+    /// purpose of providing context for the authentication and to enable users to notice if
+    /// there is something wrong about the identification and avoid attempted frauds.
+    /// </summary>
+    [JsonPropertyName("userVisibleData"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public string? UserVisibleData { get; }
+
+    /// <summary>
+    /// If present, and set to "simpleMarkdownV1", this parameter indicates that userVisibleData holds formatting characters which, if used correctly, will make the text displayed with the user nicer to look at.
+    /// For further information of formatting options, please study the document Guidelines for Formatted Text.
+    /// </summary>
+    [JsonPropertyName("userVisibleDataFormat"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public string? UserVisibleDataFormat { get; }
+
+    /// <summary>
+    /// Data not displayed to the user.
+    /// </summary>
+    [JsonPropertyName("userNonVisibleData"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public string? UserNonVisibleData { get; }
+
+    private static string ParseCallInitiator(CallInitiator callInitiator)
+    {
+        return callInitiator switch
+        {
+            Models.CallInitiator.User => callInitiator.ToString().ToLower(),
+            Models.CallInitiator.RP => callInitiator.ToString().ToUpper(),
+            _ => throw new ArgumentException(
+                $"Call initiator must be {Models.CallInitiator.User} or {Models.CallInitiator.RP}")
+        };
+    }
+
+    private static PersonalIdentityNumber ConvertToPin(string personalIdentityNumber)
+    {
+        if (string.IsNullOrWhiteSpace(personalIdentityNumber))
+        {
+            throw new ArgumentNullException(nameof(personalIdentityNumber));
+        }
+
+        if (!Identity.Swedish.PersonalIdentityNumber.TryParse(personalIdentityNumber, StrictMode.TwelveDigits, out var pin))
+        {
+            throw new ArgumentException("Wrong format", nameof(personalIdentityNumber));
+        }
+
+        return pin;
+    }
+
+    private static string? ToBase64EncodedString(string? value)
+    {
+        return value == null ? null : Convert.ToBase64String(Encoding.UTF8.GetBytes(value));
+    }
+
+    private static string? ToBase64EncodedString(byte[]? value)
+    {
+        return value == null ? null : Convert.ToBase64String(value);
+    }
+}

--- a/src/ActiveLogin.Authentication.BankId.Api/Models/PhoneRequest.cs
+++ b/src/ActiveLogin.Authentication.BankId.Api/Models/PhoneRequest.cs
@@ -1,8 +1,6 @@
 using System.Text;
 using System.Text.Json.Serialization;
 
-using ActiveLogin.Identity.Swedish;
-
 namespace ActiveLogin.Authentication.BankId.Api.Models;
 public abstract class PhoneRequest
 {
@@ -105,12 +103,12 @@ public abstract class PhoneRequest
     public PhoneRequest(string personalIdentityNumber, CallInitiator callInitiator, string? userVisibleData,
         byte[]? userNonVisibleData, PhoneRequirement? requirement, string? userVisibleDataFormat)
     {
-        if(this is PhoneSignRequest && userVisibleData == null)
+        if (this is PhoneSignRequest && userVisibleData == null)
         {
             throw new ArgumentNullException(nameof(userVisibleData));
         }
 
-        PersonalIdentityNumber = ConvertToPin(personalIdentityNumber).ToString();
+        PersonalIdentityNumber = personalIdentityNumber ?? throw new ArgumentNullException(nameof(personalIdentityNumber));
         CallInitiator = ParseCallInitiator(callInitiator);
         UserVisibleData = ToBase64EncodedString(userVisibleData);
         UserNonVisibleData = ToBase64EncodedString(userNonVisibleData);
@@ -170,23 +168,9 @@ public abstract class PhoneRequest
             Models.CallInitiator.User => callInitiator.ToString().ToLower(),
             Models.CallInitiator.RP => callInitiator.ToString().ToUpper(),
             _ => throw new ArgumentException(
-                $"Call initiator must be {Models.CallInitiator.User} or {Models.CallInitiator.RP}")
+                $"Call initiator must be {Models.CallInitiator.User} or {Models.CallInitiator.RP}",
+                nameof(callInitiator))
         };
-    }
-
-    private static PersonalIdentityNumber ConvertToPin(string personalIdentityNumber)
-    {
-        if (string.IsNullOrWhiteSpace(personalIdentityNumber))
-        {
-            throw new ArgumentNullException(nameof(personalIdentityNumber));
-        }
-
-        if (!Identity.Swedish.PersonalIdentityNumber.TryParse(personalIdentityNumber, StrictMode.TwelveDigits, out var pin))
-        {
-            throw new ArgumentException("Wrong format", nameof(personalIdentityNumber));
-        }
-
-        return pin;
     }
 
     private static string? ToBase64EncodedString(string? value)

--- a/src/ActiveLogin.Authentication.BankId.Api/Models/PhoneRequirement.cs
+++ b/src/ActiveLogin.Authentication.BankId.Api/Models/PhoneRequirement.cs
@@ -1,0 +1,42 @@
+using System.Text.Json.Serialization;
+
+namespace ActiveLogin.Authentication.BankId.Api.Models;
+
+/// <summary>
+/// Requirements on how the auth or sign order must be performed.
+/// </summary>
+public class PhoneRequirement
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="certificatePolicies">The oid in certificate policies in the user certificate. List of String.</param>
+    /// <param name="pinCode">
+    /// Users are required to sign the transaction with their PIN 
+    /// code, even if they have biometrics activated.
+    /// 
+    /// If set to true, the user is required to use pin code
+    /// If set to false, the users is not required to use pin code and are allowed to use fingerprint.
+    /// </param>
+    public PhoneRequirement(List<string>? certificatePolicies = null, bool? pinCode = null)
+    {
+        CertificatePolicies = certificatePolicies;
+        PinCode = pinCode;
+    }
+
+    /// <summary>
+    /// The oid in certificate policies in the user certificate. List of String.
+    /// </summary>
+    [JsonPropertyName("certificatePolicies"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public List<string>? CertificatePolicies { get; }
+
+    /// <summary>
+    /// Users are required to sign the transaction with their PIN 
+    /// code, even if they have biometrics activated.
+    /// 
+    /// If set to true, the user is required to use pin code
+    /// If set to false, the users is not required to use pin code and are allowed to use fingerprint.
+    /// </summary>
+    [JsonPropertyName("pinCode"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public bool? PinCode { get; }
+}

--- a/src/ActiveLogin.Authentication.BankId.Api/Models/PhoneResponse.cs
+++ b/src/ActiveLogin.Authentication.BankId.Api/Models/PhoneResponse.cs
@@ -1,0 +1,20 @@
+using System.Text.Json.Serialization;
+
+namespace ActiveLogin.Authentication.BankId.Api.Models;
+
+/// <summary>
+/// Phone auth response result.
+/// </summary>
+public abstract class PhoneResponse
+{
+    protected PhoneResponse(string orderRef)
+    {
+        OrderRef = orderRef;
+    }
+
+    /// <summary>
+    /// Used to collect the status of the order.
+    /// </summary>
+    [JsonPropertyName("orderRef")]
+    public string OrderRef { get; }
+}

--- a/src/ActiveLogin.Authentication.BankId.Api/Models/PhoneSignRequest.cs
+++ b/src/ActiveLogin.Authentication.BankId.Api/Models/PhoneSignRequest.cs
@@ -1,0 +1,36 @@
+namespace ActiveLogin.Authentication.BankId.Api.Models;
+
+/// <summary>
+/// Phone sign request parameters.
+/// </summary>
+public class PhoneSignRequest : PhoneRequest
+{
+    /// <summary></summary>
+    /// <param name="personalIdentityNumber">
+    /// The personal number of the user. String. 12 digits.
+    /// </param>
+    /// <param name="callInitiator">
+    /// Indicate if the user or the RP initiated the phone call. user: user called the RP. RP: RP called the user.
+    /// </param>
+    /// <param name="userVisibleData">
+    /// The text to be displayed and signed. The text can be formatted using CR, LF and CRLF for new lines.
+    /// </param>
+    /// <param name="userNonVisibleData">
+    /// Data not displayed to the user.
+    /// </param>
+    /// <param name="requirement">Requirements on how the phone auth or phone sign order must be performed.</param>
+    /// <param name="userVisibleDataFormat">
+    /// If present, and set to "simpleMarkdownV1", this parameter indicates that userVisibleData holds formatting characters which, if used correctly, will make the text displayed with the user nicer to look at.
+    /// For further information of formatting options, please study the document Guidelines for Formatted Text.
+    /// </param>
+    public PhoneSignRequest(
+        string personalIdentityNumber,
+        CallInitiator callInitiator,
+        string userVisibleData,
+        byte[]? userNonVisibleData = null,
+        PhoneRequirement? requirement = null,
+        string? userVisibleDataFormat = null)
+        : base(personalIdentityNumber, callInitiator, userVisibleData, userNonVisibleData, requirement, userVisibleDataFormat)
+    {
+    }
+}

--- a/src/ActiveLogin.Authentication.BankId.Api/Models/PhoneSignResponse.cs
+++ b/src/ActiveLogin.Authentication.BankId.Api/Models/PhoneSignResponse.cs
@@ -1,0 +1,9 @@
+namespace ActiveLogin.Authentication.BankId.Api.Models;
+
+public class PhoneSignResponse : PhoneResponse
+{
+    public PhoneSignResponse(string orderRef)
+        : base(orderRef)
+    {
+    }
+}

--- a/src/ActiveLogin.Authentication.BankId.Api/README.md
+++ b/src/ActiveLogin.Authentication.BankId.Api/README.md
@@ -19,6 +19,8 @@ public class BankIdAppApiClient : IBankIdAppApiClient
 {
     public Task<AuthResponse> AuthAsync(AuthRequest request) { ... }
     public Task<SignResponse> SignAsync(SignRequest request) { ... }
+    public Task<PhoneAuthResponse> PhoneAuthAsync(PhoneAuthRequest request) { ... }
+    public Task<PhoneSignResponse> PhoneSignAsync(PhoneSignRequest request) { ... }
     public Task<CollectResponse> CollectAsync(CollectRequest request) { ... }
     public Task<CancelResponse> CancelAsync(CancelRequest request) { ... }
 }

--- a/test/ActiveLogin.Authentication.BankId.Api.Test/BankIdAppApiClientExtensions_Tests.cs
+++ b/test/ActiveLogin.Authentication.BankId.Api.Test/BankIdAppApiClientExtensions_Tests.cs
@@ -61,6 +61,59 @@ public class BankIdAppApiClientExtensions_Tests
     }
 
     [Fact]
+    public async Task PhoneAuthAsync_WithPersonalNumberAndCallInitiator_ShouldMap_ToPhoneAuthRequest_WithPersonalNumberAndCallInitiator()
+    {
+        // Arrange
+        var bankIdApiClientMock = new Mock<IBankIdAppApiClient>(MockBehavior.Strict);
+        bankIdApiClientMock.Setup(client => client.PhoneAuthAsync(It.IsAny<PhoneAuthRequest>()))
+            .ReturnsAsync(It.IsAny<PhoneAuthResponse>());
+
+        // Act
+        await BankIdAppApiClientExtensions.PhoneAuthAsync(bankIdApiClientMock.Object, "201801012392", CallInitiator.RP);
+
+        // Assert
+        var request = bankIdApiClientMock.GetFirstArgumentOfFirstInvocation<IBankIdAppApiClient, PhoneAuthRequest>();
+        Assert.Equal("201801012392", request.PersonalIdentityNumber);
+        Assert.Equal("RP", request.CallInitiator);
+    }
+
+    [Fact]
+    public async Task PhoneAuthAsync_WithPersonalNumberAndCallInitiator_AndUserData_ShouldMap_ToPhoneAuthRequest_WithPersonalNumberAndCallInitiator_AndUserData_Base64Encoded()
+    {
+        // Arrange
+        var bankIdApiClientMock = new Mock<IBankIdAppApiClient>(MockBehavior.Strict);
+        bankIdApiClientMock.Setup(client => client.PhoneAuthAsync(It.IsAny<PhoneAuthRequest>()))
+            .ReturnsAsync(It.IsAny<PhoneAuthResponse>());
+
+        // Act
+        await BankIdAppApiClientExtensions.PhoneAuthAsync(bankIdApiClientMock.Object, "201801012392", CallInitiator.RP, userVisibleData: "userVisibleData", userVisibleDataFormat: "userVisibleDataFormat");
+
+        // Assert
+        var request = bankIdApiClientMock.GetFirstArgumentOfFirstInvocation<IBankIdAppApiClient, PhoneAuthRequest>();
+        Assert.Equal("201801012392", request.PersonalIdentityNumber);
+        Assert.Equal("RP", request.CallInitiator);
+        Assert.Equal("dXNlclZpc2libGVEYXRh", request.UserVisibleData);
+        Assert.Equal("userVisibleDataFormat", request.UserVisibleDataFormat);
+    }
+
+    [Fact]
+    public async Task PhoneSignAsync_WithPersonalNumberAndCallInitiator_ShouldMap_ToPhoneSignRequest_WithPersonalNumberAndCallInitiator()
+    {
+        // Arrange
+        var bankIdApiClientMock = new Mock<IBankIdAppApiClient>(MockBehavior.Strict);
+        bankIdApiClientMock.Setup(client => client.PhoneSignAsync(It.IsAny<PhoneSignRequest>()))
+            .ReturnsAsync(It.IsAny<PhoneSignResponse>());
+
+        // Act
+        await BankIdAppApiClientExtensions.PhoneSignAsync(bankIdApiClientMock.Object, "201801012392", CallInitiator.RP, "userVisibleData");
+
+        // Assert
+        var request = bankIdApiClientMock.GetFirstArgumentOfFirstInvocation<IBankIdAppApiClient, PhoneSignRequest>();
+        Assert.Equal("201801012392", request.PersonalIdentityNumber);
+        Assert.Equal("RP", request.CallInitiator);
+    }
+
+    [Fact]
     public async Task CollectAsync_WithOrderRef_ShouldMap_ToCollectRequest_WithOrderRef()
     {
         // Arrange

--- a/test/ActiveLogin.Authentication.BankId.Api.Test/BankIdAppApiClient_Tests.cs
+++ b/test/ActiveLogin.Authentication.BankId.Api.Test/BankIdAppApiClient_Tests.cs
@@ -414,7 +414,7 @@ public class BankIdAppApiClient_Tests
         // Assert
         Assert.NotNull(result);
         Assert.Equal("User", result.CallInitiator);
-        Assert.Equal(CollectCallInitiator.User, result.GetCollectCallInitiator());
+        Assert.Equal(CallInitiator.User, result.GetCollectCallInitiator());
     }
 
     [Fact]

--- a/test/ActiveLogin.Authentication.BankId.Api.Test/BankIdSimulatedAppApiClient_Tests.cs
+++ b/test/ActiveLogin.Authentication.BankId.Api.Test/BankIdSimulatedAppApiClient_Tests.cs
@@ -54,6 +54,77 @@ public class BankIdSimulatedAppApiClient_Tests
     }
 
     [Fact]
+    public async Task PhoneAuthAsync_MultiplePhoneAuthAtTheSameTime__ShouldThrow()
+    {
+        // Arange
+        var personalNumber = "201801012392";
+
+        // Act
+        await _bankIdAppClient.PhoneAuthAsync(new PhoneAuthRequest(personalNumber, CallInitiator.User));
+
+        // Assert
+        await Assert.ThrowsAsync<BankIdApiException>(() => _bankIdAppClient.PhoneAuthAsync(new PhoneAuthRequest(personalNumber, CallInitiator.User)));
+    }
+
+    [Fact]
+    public async Task PhoneAuthAsync_OneAuthAtTheTime__ShouldBeAllowed()
+    {
+        // Arange
+
+        // Act
+        var firstAuthResponse = await _bankIdAppClient.PhoneAuthAsync(new PhoneAuthRequest("201801012392", CallInitiator.User));
+        CollectResponse firstCollectResponse;
+        do
+        {
+            firstCollectResponse = await _bankIdAppClient.CollectAsync(new CollectRequest(firstAuthResponse.OrderRef));
+        } while (firstCollectResponse.GetCollectStatus() != CollectStatus.Complete);
+
+        var secondAuthResponse = await _bankIdAppClient.PhoneAuthAsync(new PhoneAuthRequest("201801012392", CallInitiator.User));
+        CollectResponse secondCollectResponse;
+        do
+        {
+            secondCollectResponse = await _bankIdAppClient.CollectAsync(new CollectRequest(secondAuthResponse.OrderRef));
+        } while (secondCollectResponse.GetCollectStatus() != CollectStatus.Complete);
+
+        // Assert
+    }
+
+    [Fact]
+    public async Task AuthAsync_PhoneAuthAsync_MultipleDifferentAuthAtTheSameTime__ShouldThrow()
+    {
+        // Arange
+
+        // Act
+        await _bankIdAppClient.AuthAsync(new AuthRequest("1.1.1.1"));
+
+        // Assert
+        await Assert.ThrowsAsync<BankIdApiException>(() => _bankIdAppClient.PhoneAuthAsync(new PhoneAuthRequest("199908072391", CallInitiator.User)));
+    }
+
+    [Fact]
+    public async Task AuthAsync_PhoneAuthAsync_OneAuthAtTheTime__ShouldBeAllowed()
+    {
+        // Arange
+
+        // Act
+        var firstAuthResponse = await _bankIdAppClient.AuthAsync(new AuthRequest("1.1.1.1"));
+        CollectResponse firstCollectResponse;
+        do
+        {
+            firstCollectResponse = await _bankIdAppClient.CollectAsync(new CollectRequest(firstAuthResponse.OrderRef));
+        } while (firstCollectResponse.GetCollectStatus() != CollectStatus.Complete);
+
+        var secondAuthResponse = await _bankIdAppClient.PhoneAuthAsync(new PhoneAuthRequest("199908072391", CallInitiator.User));
+        CollectResponse secondCollectResponse;
+        do
+        {
+            secondCollectResponse = await _bankIdAppClient.CollectAsync(new CollectRequest(secondAuthResponse.OrderRef));
+        } while (secondCollectResponse.GetCollectStatus() != CollectStatus.Complete);
+
+        // Assert
+    }
+
+    [Fact]
     public async Task CollectAsync_WithDefaultValuesInConstructor__ShouldReturnPersonInfo()
     {
         // Arange

--- a/test/ActiveLogin.Authentication.BankId.Api.Test/Models/PhoneRequest_Tests.cs
+++ b/test/ActiveLogin.Authentication.BankId.Api.Test/Models/PhoneRequest_Tests.cs
@@ -22,14 +22,11 @@ public class PhoneRequest_Tests
         Assert.Equal("personalIdentityNumber", exception.ParamName);
     }
 
-    [Theory]
-    [InlineData("1801012392")] // Missing century, only 10 digits
-    [InlineData("20180101-2392")] // Uses a dash between date and number
-    [InlineData("201801012393")] // Wrong control number, should be 2
-    public void Constructor_WhenAnyRequest_WhenInvalidPersonalIdentityNumber_ShouldThrow(string personalIdentityNumber)
+    [Fact]
+    public void Constructor_WhenAnyRequest_WhenUnknownCallInitiator_ShouldThrow()
     {
-        var exception = Assert.Throws<ArgumentException>(() => new AnyPhoneRequest(personalIdentityNumber, CallInitiator.User));
-        Assert.Equal("personalIdentityNumber", exception.ParamName);
+        var exception = Assert.Throws<ArgumentException>(() => new AnyPhoneRequest("", CallInitiator.Unknown));
+        Assert.Equal("callInitiator", exception.ParamName);
     }
 
     class AnyPhoneRequest(string personalIdentityNumber, CallInitiator callInitiator)

--- a/test/ActiveLogin.Authentication.BankId.Api.Test/Models/PhoneRequest_Tests.cs
+++ b/test/ActiveLogin.Authentication.BankId.Api.Test/Models/PhoneRequest_Tests.cs
@@ -1,0 +1,37 @@
+using System;
+
+using ActiveLogin.Authentication.BankId.Api.Models;
+
+using Xunit;
+
+namespace ActiveLogin.Authentication.BankId.Api.Test.Models;
+
+public class PhoneRequest_Tests
+{
+    [Fact]
+    public void Constructor_WhenPhoneSignRequest_WhenNoUserVisibleData_ShouldThrow()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(() => new PhoneSignRequest("", CallInitiator.User, null));
+        Assert.Equal("userVisibleData", exception.ParamName);
+    }
+
+    [Fact]
+    public void Constructor_WhenAnyRequest_WhenNoPersonalIdentityNumber_ShouldThrow()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(() => new AnyPhoneRequest(null, CallInitiator.User));
+        Assert.Equal("personalIdentityNumber", exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData("1801012392")] // Missing century, only 10 digits
+    [InlineData("20180101-2392")] // Uses a dash between date and number
+    [InlineData("201801012393")] // Wrong control number, should be 2
+    public void Constructor_WhenAnyRequest_WhenInvalidPersonalIdentityNumber_ShouldThrow(string personalIdentityNumber)
+    {
+        var exception = Assert.Throws<ArgumentException>(() => new AnyPhoneRequest(personalIdentityNumber, CallInitiator.User));
+        Assert.Equal("personalIdentityNumber", exception.ParamName);
+    }
+
+    class AnyPhoneRequest(string personalIdentityNumber, CallInitiator callInitiator)
+        : PhoneRequest(personalIdentityNumber, callInitiator, null);
+}

--- a/test/ActiveLogin.Authentication.BankId.Api.Test/Models/Request_Tests.cs
+++ b/test/ActiveLogin.Authentication.BankId.Api.Test/Models/Request_Tests.cs
@@ -1,0 +1,26 @@
+using System;
+
+using ActiveLogin.Authentication.BankId.Api.Models;
+
+using Xunit;
+
+namespace ActiveLogin.Authentication.BankId.Api.Test.Models;
+
+public class Request_Tests
+{
+    [Fact]
+    public void Constructor_WhenSignRequest_WhenNoUserVisibleData_ShouldThrow()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(() => new SignRequest("", null));
+        Assert.Equal("userVisibleData", exception.ParamName);
+    }
+
+    [Fact]
+    public void Constructor_WhenAnyRequest_WhenNoEndUserIp_ShouldThrow()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(() => new AnyRequest(null));
+        Assert.Equal("endUserIp", exception.ParamName);
+    }
+
+    class AnyRequest(string endUserIp) : Request(endUserIp, null);
+}

--- a/test/ActiveLogin.Authentication.BankId.AspNetCore.Test/BankId_Ui_Tests_Base.cs
+++ b/test/ActiveLogin.Authentication.BankId.AspNetCore.Test/BankId_Ui_Tests_Base.cs
@@ -37,6 +37,16 @@ public abstract class BankId_Ui_Tests_Base
             return _bankIdAppApiClient.SignAsync(request);
         }
 
+        public Task<PhoneAuthResponse> PhoneAuthAsync(PhoneAuthRequest request)
+        {
+            return _bankIdAppApiClient.PhoneAuthAsync(request);
+        }
+
+        public Task<PhoneSignResponse> PhoneSignAsync(PhoneSignRequest request)
+        {
+            return _bankIdAppApiClient.PhoneSignAsync(request);
+        }
+
         public Task<CollectResponse> CollectAsync(CollectRequest request)
         {
             return _bankIdAppApiClient.CollectAsync(request);


### PR DESCRIPTION
This PR fixes #404 .

High level overview of this PR:

- [x] Implemented the 2 (auth/sign) phone API endpoints
- [x] Added tests and some documentation (did I miss anything?)
- [x] Followed same structure as original auth/sign for implementation, request-/response models and tests
- [x] Renamed enum CollectCallInitiator to more general CallInitiator
- [x] Phone auth/sign are tested locally against BankID as well as simulated environment

These things have been implemented (when relevant):

- [x] Code written
- [x] Test added
- [x] Documentation updated / written
