### PR TITLE
Upgrade Nuget packages.

### DIFF
--- a/samples/IdentityServer.ClientSample/IdentityServer.ClientSample.csproj
+++ b/samples/IdentityServer.ClientSample/IdentityServer.ClientSample.csproj
@@ -18,7 +18,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.4" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.6" />
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
     </ItemGroup>
 

--- a/samples/IdentityServer.ServerSample/IdentityServer.ServerSample.csproj
+++ b/samples/IdentityServer.ServerSample/IdentityServer.ServerSample.csproj
@@ -19,9 +19,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Duende.IdentityServer" Version="7.0.4" />
+        <PackageReference Include="Duende.IdentityServer" Version="7.0.5" />
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.4" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.6" />
         <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.22.0" />
     </ItemGroup>
 

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/ActiveLogin.Authentication.BankId.AspNetCore.csproj
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/ActiveLogin.Authentication.BankId.AspNetCore.csproj
@@ -55,7 +55,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="5.4.4">
+        <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="5.4.5">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/ActiveLogin.Authentication.BankId.AzureKeyVault/ActiveLogin.Authentication.BankId.AzureKeyVault.csproj
+++ b/src/ActiveLogin.Authentication.BankId.AzureKeyVault/ActiveLogin.Authentication.BankId.AzureKeyVault.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Azure.Identity" Version="1.11.2" />
+        <PackageReference Include="Azure.Identity" Version="1.12.0" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
     </ItemGroup>
 

--- a/test/ActiveLogin.Authentication.BankId.Api.Test/ActiveLogin.Authentication.BankId.Api.Test.csproj
+++ b/test/ActiveLogin.Authentication.BankId.Api.Test/ActiveLogin.Authentication.BankId.Api.Test.csproj
@@ -4,10 +4,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
         <PackageReference Include="Moq" Version="4.20.70" />
-        <PackageReference Include="xunit" Version="2.8.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+        <PackageReference Include="xunit" Version="2.8.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>

--- a/test/ActiveLogin.Authentication.BankId.AspNetCore.Test/ActiveLogin.Authentication.BankId.AspNetCore.Test.csproj
+++ b/test/ActiveLogin.Authentication.BankId.AspNetCore.Test/ActiveLogin.Authentication.BankId.AspNetCore.Test.csproj
@@ -6,12 +6,12 @@
 
     <ItemGroup>
         <PackageReference Include="AngleSharp" Version="1.1.2" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.4" />
-        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.4" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.6" />
+        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.6" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
         <PackageReference Include="Moq" Version="4.20.70" />
-        <PackageReference Include="xunit" Version="2.8.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+        <PackageReference Include="xunit" Version="2.8.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>

--- a/test/ActiveLogin.Authentication.BankId.AzureKeyVault.Test/ActiveLogin.Authentication.BankId.AzureKeyVault.Test.csproj
+++ b/test/ActiveLogin.Authentication.BankId.AzureKeyVault.Test/ActiveLogin.Authentication.BankId.AzureKeyVault.Test.csproj
@@ -4,9 +4,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-        <PackageReference Include="xunit" Version="2.8.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+        <PackageReference Include="xunit" Version="2.8.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/test/ActiveLogin.Authentication.BankId.Core.Test/ActiveLogin.Authentication.BankId.Core.Test.csproj
+++ b/test/ActiveLogin.Authentication.BankId.Core.Test/ActiveLogin.Authentication.BankId.Core.Test.csproj
@@ -5,10 +5,10 @@
 
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
         <PackageReference Include="Moq" Version="4.20.70" />
-        <PackageReference Include="xunit" Version="2.8.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+        <PackageReference Include="xunit" Version="2.8.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>

--- a/test/ActiveLogin.Authentication.BankId.UAParser.Test/ActiveLogin.Authentication.BankId.UAParser.Test.csproj
+++ b/test/ActiveLogin.Authentication.BankId.UAParser.Test/ActiveLogin.Authentication.BankId.UAParser.Test.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="xunit" Version="2.8.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Bumps [Azure.Identity] from 1.11.2 to 1.12.6.
Bumps [Duende.IdentityServer] from 7.0.4 to 7.0.5.
Bumps [Microsoft.AspNetCore.Authentication.OpenIdConnect] from 8.0.4 to 8.0.6.
Bumps [Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation] from 8.0.4 to 8.0.6.
Bumps [Microsoft.AspNetCore.Mvc.Testing] from 8.0.4 to 8.0.6.
Bumps [Microsoft.AspNetCore.TestHost] from 8.0.4 to 8.0.6.
Bumps [Microsoft.NET.Test.Sdk] from 17.9.0 to 17.10.0.
Bumps [Microsoft.TypeScript.MSBuild] from 5.4.4 to 5.4.5.
Bumps [xunit] from 2.8.0 to 2.8.1.
Bumps [xunit.runner.visualstudio] from 2.8.0 to 2.8.1.