### PR TITLE
Set requirements on how the authentication or signing order must be performed dynamically

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "8.0.403",
+        "version": "8.0.404",
         "rollForward": "latestFeature"
     }
 }

--- a/src/ActiveLogin.Authentication.BankId.Api/Models/Requirement.cs
+++ b/src/ActiveLogin.Authentication.BankId.Api/Models/Requirement.cs
@@ -68,7 +68,7 @@ public class Requirement
     /// A personal number to be used to complete the transaction. If a BankID with another personal number attempts to sign the transaction, it fails.
     /// </summary>
     [JsonPropertyName("personalNumber"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    public string? PersonalNumber { get; set; }
+    public string? PersonalNumber { get; }
 
     /// <summary>
     /// Set the acceptable risk level for the transaction.

--- a/src/ActiveLogin.Authentication.BankId.Api/Models/Requirement.cs
+++ b/src/ActiveLogin.Authentication.BankId.Api/Models/Requirement.cs
@@ -68,7 +68,7 @@ public class Requirement
     /// A personal number to be used to complete the transaction. If a BankID with another personal number attempts to sign the transaction, it fails.
     /// </summary>
     [JsonPropertyName("personalNumber"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    public string? PersonalNumber { get; }
+    public string? PersonalNumber { get; set; }
 
     /// <summary>
     /// Set the acceptable risk level for the transaction.

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/ActiveLogin/Controllers/BankIdUiSignApiController.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/ActiveLogin/Controllers/BankIdUiSignApiController.cs
@@ -69,6 +69,8 @@ public class BankIdUiSignApiController : BankIdUiApiControllerBase
                     UserNonVisibleData = state.BankIdSignProperties.UserNonVisibleData,
                     UserVisibleDataFormat = state.BankIdSignProperties.UserVisibleDataFormat,
                     RequiredPersonalIdentityNumber = state.BankIdSignProperties.RequiredPersonalIdentityNumber,
+                    RequireMrtd = state.BankIdSignProperties.RequireMrtd,
+                    RequirePinCode = state.BankIdSignProperties.RequirePinCode,
                 },
                 returnRedirectUrl);
         }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/ActiveLogin/Controllers/BankIdUiSignApiController.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/ActiveLogin/Controllers/BankIdUiSignApiController.cs
@@ -67,7 +67,8 @@ public class BankIdUiSignApiController : BankIdUiApiControllerBase
                 {
                     Items = state.BankIdSignProperties.Items,
                     UserNonVisibleData = state.BankIdSignProperties.UserNonVisibleData,
-                    UserVisibleDataFormat = state.BankIdSignProperties.UserVisibleDataFormat
+                    UserVisibleDataFormat = state.BankIdSignProperties.UserVisibleDataFormat,
+                    RequiredPersonalIdentityNumber = state.BankIdSignProperties.RequiredPersonalIdentityNumber,
                 },
                 returnRedirectUrl);
         }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Auth/AuthenticationBuilderBankIdExtensions.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Auth/AuthenticationBuilderBankIdExtensions.cs
@@ -2,6 +2,7 @@ using ActiveLogin.Authentication.BankId.AspNetCore.ApplicationFeatureProviders;
 using ActiveLogin.Authentication.BankId.AspNetCore.ClaimsTransformation;
 using ActiveLogin.Authentication.BankId.AspNetCore.DataProtection;
 using ActiveLogin.Authentication.BankId.Core;
+using ActiveLogin.Authentication.BankId.Core.Requirements;
 using ActiveLogin.Authentication.BankId.Core.UserData;
 
 using Microsoft.AspNetCore.Authentication;
@@ -77,5 +78,6 @@ public static class AuthenticationBuilderBankIdAuthExtensions
         builder.AddClaimsTransformer<BankIdDefaultClaimsTransformer>();
 
         builder.UseAuthRequestUserDataResolver<BankIdAuthRequestEmptyUserDataResolver>();
+        builder.UseAuthRequestRequirementsResolver<BankIdAuthRequestEmptyRequirementsResolver>();
     }
 }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Auth/IBankIdAuthBuilderExtensions.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Auth/IBankIdAuthBuilderExtensions.cs
@@ -1,4 +1,5 @@
 using ActiveLogin.Authentication.BankId.AspNetCore.ClaimsTransformation;
+using ActiveLogin.Authentication.BankId.Core.Requirements;
 using ActiveLogin.Authentication.BankId.Core.UserData;
 
 using Microsoft.Extensions.DependencyInjection;
@@ -57,6 +58,19 @@ public static class IBankIdAuthBuilderExtensions
     public static IBankIdAuthBuilder UseAuthRequestUserDataResolver<TBankIdAuthRequestUserDataResolverImplementation>(this IBankIdAuthBuilder builder) where TBankIdAuthRequestUserDataResolverImplementation : class, IBankIdAuthRequestUserDataResolver
     {
         builder.Services.AddTransient<IBankIdAuthRequestUserDataResolver, TBankIdAuthRequestUserDataResolverImplementation>();
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Use a custom requirements resolver.
+    /// </summary>
+    /// <typeparam name="TBankIdAuthRequestRequirementsResolverImplementation"></typeparam>
+    /// <param name="builder"></param>
+    /// <returns></returns>
+    public static IBankIdAuthBuilder UseAuthRequestRequirementsResolver<TBankIdAuthRequestRequirementsResolverImplementation>(this IBankIdAuthBuilder builder) where TBankIdAuthRequestRequirementsResolverImplementation : class, IBankIdAuthRequestRequirementsResolver
+    {
+        builder.Services.AddTransient<IBankIdAuthRequestRequirementsResolver, TBankIdAuthRequestRequirementsResolverImplementation>();
 
         return builder;
     }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/DataProtection/Serialization/BankIdUiStateSerializer.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/DataProtection/Serialization/BankIdUiStateSerializer.cs
@@ -100,7 +100,7 @@ internal class BankIdUiStateSerializer : BankIdDataSerializer<BankIdUiState>
             {
                 UserVisibleDataFormat = userVisibleDataFormat,
                 UserNonVisibleData = userNonVisibleData,
-                RequiredPersonalIdentityNumber = PersonalIdentityNumber.Parse(requiredPersonalIdentityNumber),
+                RequiredPersonalIdentityNumber = requiredPersonalIdentityNumber != null ? PersonalIdentityNumber.Parse(requiredPersonalIdentityNumber) : null,
 
                 Items = items
             };

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/DataProtection/Serialization/BankIdUiStateSerializer.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/DataProtection/Serialization/BankIdUiStateSerializer.cs
@@ -1,6 +1,7 @@
 using ActiveLogin.Authentication.BankId.AspNetCore.Auth;
 using ActiveLogin.Authentication.BankId.AspNetCore.Models;
 using ActiveLogin.Authentication.BankId.AspNetCore.Sign;
+using ActiveLogin.Identity.Swedish;
 
 using Microsoft.AspNetCore.Authentication;
 
@@ -37,6 +38,9 @@ internal class BankIdUiStateSerializer : BankIdDataSerializer<BankIdUiState>
                 writer.Write(item.Key ?? string.Empty);
                 writer.Write(item.Value ?? string.Empty);
             }
+
+            writer.Write(signState.BankIdSignProperties.RequiredPersonalIdentityNumber == null);
+            writer.Write(signState.BankIdSignProperties.RequiredPersonalIdentityNumber?.To12DigitString() ?? string.Empty);
         }
         else
         {
@@ -85,10 +89,18 @@ internal class BankIdUiStateSerializer : BankIdDataSerializer<BankIdUiState>
                 items.Add(key, value);
             }
 
+            var requiredPersonalIdentityNumberIsNull = reader.ReadBoolean();
+            var requiredPersonalIdentityNumber = reader.ReadString();
+            if (requiredPersonalIdentityNumberIsNull)
+            {
+                requiredPersonalIdentityNumber = null;
+            }
+
             var bankIdSignProperties = new BankIdSignProperties(userVisibleData)
             {
                 UserVisibleDataFormat = userVisibleDataFormat,
                 UserNonVisibleData = userNonVisibleData,
+                RequiredPersonalIdentityNumber = PersonalIdentityNumber.Parse(requiredPersonalIdentityNumber),
 
                 Items = items
             };

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Sign/BankIdSignProperties.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Sign/BankIdSignProperties.cs
@@ -35,6 +35,7 @@ public class BankIdSignProperties
     /// there is something wrong about the identification and avoid attempted frauds.
     /// </summary>
     public string UserVisibleData { get; set; }
+
     /// <summary>
     /// If present, and set to "simpleMarkdownV1", this parameter indicates that userVisibleData holds formatting characters which, if used correctly, will make the text displayed with the user nicer to look at.
     /// For further information of formatting options, please study the document Guidelines for Formatted Text.
@@ -53,6 +54,16 @@ public class BankIdSignProperties
     /// </summary>
     public PersonalIdentityNumber? RequiredPersonalIdentityNumber { get; set; }
 
+    /// <summary>
+    /// Whether the user needs to confirm their identity with a valid Swedish passport or national ID card to complete the order.
+    /// No identity confirmation is required by default.
+    /// </summary>
+    public bool? RequireMrtd { get; set; }
+
+    /// <summary>
+    /// Users are required to confirm the order with their security code even if they have biometrics activated.
+    /// </summary>
+    public bool? RequirePinCode { get; set; }
 
     /// <summary>
     /// A collection of items where you can store state that will be provided once the sign flow is done.

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Sign/BankIdSignProperties.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Sign/BankIdSignProperties.cs
@@ -1,3 +1,5 @@
+using ActiveLogin.Identity.Swedish;
+
 namespace ActiveLogin.Authentication.BankId.AspNetCore.Sign;
 
 public class BankIdSignProperties
@@ -43,6 +45,14 @@ public class BankIdSignProperties
     /// Data not displayed to the user.
     /// </summary>
     public byte[]? UserNonVisibleData { get; set; }
+
+    /// <summary>
+    /// The personal identity number allowed to confirm the sign request.
+    /// If a BankID with another personal identity number attempts to confirm the sign request, it will fail.
+    /// If left empty any personal identity number will be allowed.
+    /// </summary>
+    public PersonalIdentityNumber? RequiredPersonalIdentityNumber { get; set; }
+
 
     /// <summary>
     /// A collection of items where you can store state that will be provided once the sign flow is done.

--- a/src/ActiveLogin.Authentication.BankId.Core/Flow/BankIdFlowService.cs
+++ b/src/ActiveLogin.Authentication.BankId.Core/Flow/BankIdFlowService.cs
@@ -102,10 +102,12 @@ public class BankIdFlowService : IBankIdFlowService
         var resolvedCertificatePolicies = GetResolvedCertificatePolicies(flowOptions);
         var resolvedRiskLevel = flowOptions.AllowedRiskLevel == Risk.BankIdAllowedRiskLevel.NoRiskLevel ? null : flowOptions.AllowedRiskLevel.ToString().ToLower();
 
-        var authRequestRequirement = new Requirement(resolvedCertificatePolicies, resolvedRiskLevel, flowOptions.RequirePinCode, flowOptions.RequireMrtd);
+        var authRequestRequirement = new Requirement(resolvedCertificatePolicies, resolvedRiskLevel, flowOptions.RequirePinCode, flowOptions.RequireMrtd, flowOptions.RequiredPersonalIdentityNumber?.To12DigitString());
 
         var authRequestContext = new BankIdAuthRequestContext(endUserIp, authRequestRequirement);
         var userData = await _bankIdAuthUserDataResolver.GetUserDataAsync(authRequestContext);
+
+        authRequestRequirement.PersonalNumber = userData.RequiredPersonalIdentityNumber?.To12DigitString();
 
         return new AuthRequest(
             endUserIp,

--- a/src/ActiveLogin.Authentication.BankId.Core/Flow/BankIdFlowService.cs
+++ b/src/ActiveLogin.Authentication.BankId.Core/Flow/BankIdFlowService.cs
@@ -107,7 +107,10 @@ public class BankIdFlowService : IBankIdFlowService
         var authRequestContext = new BankIdAuthRequestContext(endUserIp, authRequestRequirement);
         var userData = await _bankIdAuthUserDataResolver.GetUserDataAsync(authRequestContext);
 
-        authRequestRequirement.PersonalNumber = userData.RequiredPersonalIdentityNumber?.To12DigitString();
+        if (userData.RequiredPersonalIdentityNumber != null)
+        {
+            authRequestRequirement.PersonalNumber = userData.RequiredPersonalIdentityNumber.To12DigitString();
+        }
 
         return new AuthRequest(
             endUserIp,
@@ -163,7 +166,8 @@ public class BankIdFlowService : IBankIdFlowService
         var resolvedCertificatePolicies = GetResolvedCertificatePolicies(flowOptions);
         var resolvedRiskLevel = flowOptions.AllowedRiskLevel == Risk.BankIdAllowedRiskLevel.NoRiskLevel ? null : flowOptions.AllowedRiskLevel.ToString().ToLower();
 
-        var requestRequirement = new Requirement(resolvedCertificatePolicies, resolvedRiskLevel, flowOptions.RequirePinCode, flowOptions.RequireMrtd, flowOptions.RequiredPersonalIdentityNumber?.To12DigitString());
+        var personalIdentityNumber = bankIdSignData.RequiredPersonalIdentityNumber ?? flowOptions.RequiredPersonalIdentityNumber;
+        var requestRequirement = new Requirement(resolvedCertificatePolicies, resolvedRiskLevel, flowOptions.RequirePinCode, flowOptions.RequireMrtd, personalIdentityNumber?.To12DigitString());
 
         return new SignRequest(
             endUserIp,

--- a/src/ActiveLogin.Authentication.BankId.Core/Flow/BankIdFlowService.cs
+++ b/src/ActiveLogin.Authentication.BankId.Core/Flow/BankIdFlowService.cs
@@ -166,8 +166,10 @@ public class BankIdFlowService : IBankIdFlowService
         var resolvedCertificatePolicies = GetResolvedCertificatePolicies(flowOptions);
         var resolvedRiskLevel = flowOptions.AllowedRiskLevel == Risk.BankIdAllowedRiskLevel.NoRiskLevel ? null : flowOptions.AllowedRiskLevel.ToString().ToLower();
 
-        var personalIdentityNumber = bankIdSignData.RequiredPersonalIdentityNumber ?? flowOptions.RequiredPersonalIdentityNumber;
-        var requestRequirement = new Requirement(resolvedCertificatePolicies, resolvedRiskLevel, flowOptions.RequirePinCode, flowOptions.RequireMrtd, personalIdentityNumber?.To12DigitString());
+        var requiredPersonalIdentityNumber = bankIdSignData.RequiredPersonalIdentityNumber ?? flowOptions.RequiredPersonalIdentityNumber;
+        var requireMrtd = bankIdSignData.RequireMrtd ?? flowOptions.RequireMrtd;
+        var requirePinCode = bankIdSignData.RequirePinCode ?? flowOptions.RequirePinCode;
+        var requestRequirement = new Requirement(resolvedCertificatePolicies, resolvedRiskLevel, requirePinCode, requireMrtd, requiredPersonalIdentityNumber?.To12DigitString());
 
         return new SignRequest(
             endUserIp,

--- a/src/ActiveLogin.Authentication.BankId.Core/Models/BankIdSignData.cs
+++ b/src/ActiveLogin.Authentication.BankId.Core/Models/BankIdSignData.cs
@@ -15,6 +15,8 @@ public class BankIdSignData
     public byte[]? UserNonVisibleData { get; set; }
 
     public PersonalIdentityNumber? RequiredPersonalIdentityNumber { get; set; }
+    public bool? RequireMrtd { get; set; }
+    public bool? RequirePinCode { get; set; }
 
     public IDictionary<string, string?> Items { get; set; } = new Dictionary<string, string?>();
 }

--- a/src/ActiveLogin.Authentication.BankId.Core/Models/BankIdSignData.cs
+++ b/src/ActiveLogin.Authentication.BankId.Core/Models/BankIdSignData.cs
@@ -1,3 +1,5 @@
+using ActiveLogin.Identity.Swedish;
+
 namespace ActiveLogin.Authentication.BankId.Core.Models;
 
 public class BankIdSignData
@@ -11,6 +13,8 @@ public class BankIdSignData
     public string? UserVisibleDataFormat { get; set; }
 
     public byte[]? UserNonVisibleData { get; set; }
+
+    public PersonalIdentityNumber? RequiredPersonalIdentityNumber { get; set; }
 
     public IDictionary<string, string?> Items { get; set; } = new Dictionary<string, string?>();
 }

--- a/src/ActiveLogin.Authentication.BankId.Core/Requirements/BankIdAuthRequestEmptyRequirementsResolver.cs
+++ b/src/ActiveLogin.Authentication.BankId.Core/Requirements/BankIdAuthRequestEmptyRequirementsResolver.cs
@@ -1,0 +1,11 @@
+﻿namespace ActiveLogin.Authentication.BankId.Core.Requirements;
+
+public class BankIdAuthRequestEmptyRequirementsResolver : IBankIdAuthRequestRequirementsResolver
+{
+    public static readonly BankIdAuthRequirements EmptyAuthRequirements = new();
+
+    public Task<BankIdAuthRequirements> GetRequirementsAsync()
+    {
+        return Task.FromResult(EmptyAuthRequirements);
+    }
+}

--- a/src/ActiveLogin.Authentication.BankId.Core/Requirements/BankIdAuthRequirements.cs
+++ b/src/ActiveLogin.Authentication.BankId.Core/Requirements/BankIdAuthRequirements.cs
@@ -1,0 +1,24 @@
+using ActiveLogin.Identity.Swedish;
+
+namespace ActiveLogin.Authentication.BankId.Core.Requirements;
+
+public class BankIdAuthRequirements
+{
+    /// <summary>
+    /// The personal identity number allowed to confirm the identification.
+    /// If a BankID with another personal identity number attempts to confirm the identification, it will fail.
+    /// If left empty any personal identity number will be allowed.
+    /// </summary>
+    public PersonalIdentityNumber? RequiredPersonalIdentityNumber { get; set; }
+
+    /// <summary>
+    /// Whether the user needs to confirm their identity with a valid Swedish passport or national ID card to complete the order.
+    /// No identity confirmation is required by default.
+    /// </summary>
+    public bool? RequireMrtd { get; set; }
+
+    /// <summary>
+    /// Users are required to confirm the order with their security code even if they have biometrics activated.
+    /// </summary>
+    public bool? RequirePinCode { get; set; }
+}

--- a/src/ActiveLogin.Authentication.BankId.Core/Requirements/IBankIdAuthRequestRequirementsResolver.cs
+++ b/src/ActiveLogin.Authentication.BankId.Core/Requirements/IBankIdAuthRequestRequirementsResolver.cs
@@ -1,0 +1,13 @@
+namespace ActiveLogin.Authentication.BankId.Core.Requirements;
+
+/// <summary>
+/// Resolve auth request requirements.
+/// </summary>
+public interface IBankIdAuthRequestRequirementsResolver
+{
+    /// <summary>
+    /// Returns the requirements for the current request.
+    /// </summary>
+    /// <returns></returns>
+    Task<BankIdAuthRequirements> GetRequirementsAsync();
+}

--- a/src/ActiveLogin.Authentication.BankId.Core/ServiceCollectionBankIdExtensions.cs
+++ b/src/ActiveLogin.Authentication.BankId.Core/ServiceCollectionBankIdExtensions.cs
@@ -5,6 +5,7 @@ using ActiveLogin.Authentication.BankId.Api.UserMessage;
 using ActiveLogin.Authentication.BankId.Core.Events.Infrastructure;
 using ActiveLogin.Authentication.BankId.Core.Flow;
 using ActiveLogin.Authentication.BankId.Core.Qr;
+using ActiveLogin.Authentication.BankId.Core.Requirements;
 using ActiveLogin.Authentication.BankId.Core.ResultStore;
 using ActiveLogin.Authentication.BankId.Core.SupportedDevice;
 using ActiveLogin.Authentication.BankId.Core.UserData;
@@ -68,6 +69,7 @@ public static class ServiceCollectionBankIdExtensions
 
         services.AddTransient<IBankIdUserMessageLocalizer, BankIdUserMessageLocalizer>();
         services.AddTransient<IBankIdAuthRequestUserDataResolver, BankIdAuthRequestEmptyUserDataResolver>();
+        services.AddTransient<IBankIdAuthRequestRequirementsResolver, BankIdAuthRequestEmptyRequirementsResolver>();
 
         builder.AddEventListener<BankIdLoggerEventListener>();
         builder.AddEventListener<BankIdResultStoreEventListener>();

--- a/src/ActiveLogin.Authentication.BankId.Core/UserData/BankIdAuthUserData.cs
+++ b/src/ActiveLogin.Authentication.BankId.Core/UserData/BankIdAuthUserData.cs
@@ -1,3 +1,5 @@
+using ActiveLogin.Identity.Swedish;
+
 namespace ActiveLogin.Authentication.BankId.Core.UserData;
 
 public class BankIdAuthUserData
@@ -5,4 +7,6 @@ public class BankIdAuthUserData
     public string? UserVisibleData { get; set; }
     public byte[]? UserNonVisibleData { get; set; }
     public string? UserVisibleDataFormat { get; set; }
+
+    public PersonalIdentityNumber? RequiredPersonalIdentityNumber { get; set; }
 }

--- a/src/ActiveLogin.Authentication.BankId.Core/UserData/BankIdAuthUserData.cs
+++ b/src/ActiveLogin.Authentication.BankId.Core/UserData/BankIdAuthUserData.cs
@@ -7,10 +7,4 @@ public class BankIdAuthUserData
     public string? UserVisibleData { get; set; }
     public byte[]? UserNonVisibleData { get; set; }
     public string? UserVisibleDataFormat { get; set; }
-
-    /// <summary>
-    /// The personal identity number allowed to confirm the identification. If a BankID with another personal identity number
-    /// attempts to confirm the identification, it will fail. If left empty any personal identity number will be allowed.
-    /// </summary>
-    public PersonalIdentityNumber? RequiredPersonalIdentityNumber { get; set; }
 }

--- a/src/ActiveLogin.Authentication.BankId.Core/UserData/BankIdAuthUserData.cs
+++ b/src/ActiveLogin.Authentication.BankId.Core/UserData/BankIdAuthUserData.cs
@@ -8,5 +8,9 @@ public class BankIdAuthUserData
     public byte[]? UserNonVisibleData { get; set; }
     public string? UserVisibleDataFormat { get; set; }
 
+    /// <summary>
+    /// The personal identity number allowed to confirm the identification. If a BankID with another personal identity number
+    /// attempts to confirm the identification, it will fail. If left empty any personal identity number will be allowed.
+    /// </summary>
     public PersonalIdentityNumber? RequiredPersonalIdentityNumber { get; set; }
 }

--- a/test/ActiveLogin.Authentication.BankId.Api.Test/BankIdAppApiClient_Tests.cs
+++ b/test/ActiveLogin.Authentication.BankId.Api.Test/BankIdAppApiClient_Tests.cs
@@ -167,6 +167,56 @@ public class BankIdAppApiClient_Tests
     }
 
     [Fact]
+    public async Task AuthAsync_WithAuthRequest__ShouldHaveReturnRisk()
+    {
+        //Arrange
+        byte[] userNonVisibleData = Encoding.ASCII.GetBytes("Hello");
+        string asBase64 = Convert.ToBase64String(userNonVisibleData);
+
+        //Act
+        await _bankIdAppApiClient.AuthAsync(new AuthRequest("1.1.1.1", null, null, null, null, null, true));
+
+        //Assert
+        var request = _messageHandlerMock.GetFirstArgumentOfFirstInvocation<HttpMessageHandler, HttpRequestMessage>();
+        var contentString = await request.Content.ReadAsStringAsync();
+
+        JsonTests.AssertProperty(contentString, "endUserIp", "1.1.1.1");
+        JsonTests.AssertPropertyIsEmptyObject(contentString, "requirement");
+        JsonTests.AssertProperty(contentString, "returnRisk", true);
+        JsonTests.AssertOnlyProperties(contentString, new[]
+        {
+            "endUserIp",
+            "requirement",
+            "returnRisk",
+        });
+    }
+
+    [Fact]
+    public async Task AuthAsync_WithAuthRequest__ShouldHaveReturnUrl()
+    {
+        //Arrange
+        byte[] userNonVisibleData = Encoding.ASCII.GetBytes("Hello");
+        string asBase64 = Convert.ToBase64String(userNonVisibleData);
+
+        //Act
+        await _bankIdAppApiClient.AuthAsync(new AuthRequest("1.1.1.1", null, null, null, null, "http://mywebpage.com", null));
+
+        //Assert
+        var request = _messageHandlerMock.GetFirstArgumentOfFirstInvocation<HttpMessageHandler, HttpRequestMessage>();
+        var contentString = await request.Content.ReadAsStringAsync();
+
+        JsonTests.AssertProperty(contentString, "endUserIp", "1.1.1.1");
+        JsonTests.AssertPropertyIsEmptyObject(contentString, "requirement");
+        JsonTests.AssertProperty(contentString, "returnUrl", "http://mywebpage.com");
+        JsonTests.AssertOnlyProperties(contentString, new[]
+        {
+            "endUserIp",
+            "requirement",
+            "returnUrl",
+        });
+    }
+
+    [Fact]
     public async Task SignAsync_WithSignRequest__ShouldPostToBankIdSign_WithJsonPayload()
     {
         // Arrange


### PR DESCRIPTION
This PR fixes #459 #476 

High level overview of this PR:

- [x] Make it possible to register your own requirements resolver to set the requirements on how the authentication order must be performed (sent to the BankID API as part of the auth request) dynamically instead of statically during startup in Program.cs. In the same way as for user data (IBankIdAuthRequestUserDataResolver) and end user ip (IBankIdEndUserIpResolver). 
- [x] Allow setting requirements (sent to the BankID API in the sign request) using BankIdSignProperties.
- [x] Update documentation with the above features.
