### PR TITLE
Fix code scanning alert no. 124: Cross-site scripting

### DIFF
--- a/samples/IdentityServer.ServerSample/Controllers/AccountController.cs
+++ b/samples/IdentityServer.ServerSample/Controllers/AccountController.cs
@@ -2,7 +2,7 @@ using IdentityServer.ServerSample.Models;
 using Duende.IdentityServer.Services;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Mvc;
-
+using System.Net;
 namespace IdentityServer.ServerSample.Controllers;
 
 public class AccountController : Controller
@@ -23,7 +23,8 @@ public class AccountController : Controller
         var providers = schemes
             .Where(x => x.DisplayName != null)
             .Select(x => new ExternalProvider(x.DisplayName ?? x.Name, x.Name));
-        var viewModel = new AccountLoginViewModel(providers, returnUrl);
+        var sanitizedReturnUrl = System.Net.WebUtility.HtmlEncode(returnUrl);
+        var viewModel = new AccountLoginViewModel(providers, sanitizedReturnUrl);
 
         return View(viewModel);
     }

--- a/samples/IdentityServer.ServerSample/Views/Account/Login.cshtml
+++ b/samples/IdentityServer.ServerSample/Views/Account/Login.cshtml
@@ -17,7 +17,7 @@
                 <a class="btn btn-primary btn-lg"
                    asp-action="ExternalLogin"
                    asp-route-provider="@provider.AuthenticationScheme"
-                   asp-route-returnUrl="@Model.ReturnUrl">
+                   asp-route-returnUrl="@Html.Raw(Model.ReturnUrl)">
                     @provider.DisplayName
                 </a>
             }


### PR DESCRIPTION
Fixes [https://github.com/ActiveLogin/ActiveLogin.Authentication/security/code-scanning/124](https://github.com/ActiveLogin/ActiveLogin.Authentication/security/code-scanning/124)

To fix the cross-site scripting vulnerability, we need to sanitize the `returnUrl` parameter before rendering it in the view. The best way to do this is to use the `System.Net.WebUtility.HtmlEncode` method to encode the `returnUrl` value. This will ensure that any potentially malicious scripts in the `returnUrl` are rendered as plain text and not executed by the browser.

We will make the following changes:
1. Sanitize the `returnUrl` parameter in the `AccountController` before passing it to the view.
2. Update the `Login.cshtml` view to use the sanitized `returnUrl`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
