### PR TITLE
Simulated API errors

### DIFF
--- a/docs/articles/bankid.md
+++ b/docs/articles/bankid.md
@@ -36,6 +36,7 @@ The most common scenbario is to use Active Login for BankID auth/login, so most 
   + [Handle missing or invalid state cookie](#handle-missing-or-invalid-state-cookie)
   + [Multi tenant scenario](#multi-tenant-scenario)
   + [Customize the UI](#customize-the-ui)
+  + [Simulate BankID API errors](#simulate-bankid-api-errors)
   + [Event listeners](#event-listeners)
   + [Store data on auth completion](#store-data-on-auth-completion)
   + [Resolve the end user ip](#resolve-the-end-user-ip)
@@ -789,6 +790,35 @@ If you want, you can override the UI for Auth and Sign with different templates.
 
 See [the MVC sample](https://github.com/ActiveLogin/ActiveLogin.Authentication/tree/main/samples/Standalone.MvcSample) to see this in action, as demonstrated [here](https://github.com/ActiveLogin/ActiveLogin.Authentication/tree/main/samples/Standalone.MvcSample/Areas/ActiveLogin/Views/BankIdUiAuth/_Wrapper.cshtml).
 
+### Simulate BankID API errors
+
+When developing and testing your application, it can be useful to simulate various BankID API errors to ensure your application handles them gracefully. ActiveLogin provides a way to simulate these errors in any environment.
+
+The BankIdBuilder has an extension method `AddSimulatedBankIdApiError` that can be used to simulate errors.
+The method takes the parameters:
+- `errorRate`: The rate of errors to simulate, a value between 0 and 1. For example, 0.5 will simulate an error in 50% of the requests.
+- `errors`: The errors that will be used to simulate. The errors are defined in a Dictionary with the key being an `ErrorCod e` Enum and the value being the ErrorDescription.
+- `varyErrorTypes`: If true, the error type will be varied between the errors in the list. If false, the same random error type will be used for all API calls.
+
+#### Simulated API error usage
+
+The example below will fail 20% of the API calls to BankId with either a RequestTimeout or InternalError.
+The error type will be varied between the errors.
+```csharp
+services
+    .AddBankId(bankId =>
+    {
+        bankId.UseSimulatedEnvironment();
+        bankId.AddSimulatedApiErrors(
+            errorRate: 0.2,
+            errors: new Dictionary<ErrorCode, string>()
+            {
+                { ErrorCode.RequestTimeout, "Timeout in API" },
+                { ErrorCode.InternalError, "Internal error in API" }
+            },
+            varyErrorTypes: true);
+    });
+```
 
 ### Event listeners
 

--- a/src/ActiveLogin.Authentication.BankId.Api/BankIdErrorSimulatedApiClientDecorator.cs
+++ b/src/ActiveLogin.Authentication.BankId.Api/BankIdErrorSimulatedApiClientDecorator.cs
@@ -1,0 +1,112 @@
+using ActiveLogin.Authentication.BankId.Api.Models;
+
+namespace ActiveLogin.Authentication.BankId.Api;
+
+/// <summary>
+/// This decorator simulates errors from the BankID API.
+/// An error is thrown with a probability of <paramref name="errorRate"/>.
+/// The error is one of the errors in <paramref name="errors"/>.
+/// An error is thrown only once for each session.
+/// The session is based on the <see cref="Response.OrderRef"></see> property.
+/// </summary>
+/// <param name="decorated">The decorated ApiClient <see cref="IBankIdAppApiClient"></see></param>
+/// <param name="errorRate">Probability of error</param>
+/// <param name="errors">Errors to use</param>
+/// <param name="varyErrorTypes">If true, the error type will vary between requests</param>
+public class BankIdErrorSimulatedApiClientDecorator(
+    IBankIdAppApiClient decorated,
+    double? errorRate = null,
+    Dictionary<ErrorCode, string>? errors = null,
+    bool? varyErrorTypes = null) : IBankIdAppApiClient
+{
+    private readonly Dictionary<ErrorCode, string> _errors = errors ?? new Dictionary<ErrorCode, string>()
+    {
+        { ErrorCode.AlreadyInProgress , "Already in progress"},
+        { ErrorCode.Maintenance , "Maintenance"},
+        { ErrorCode.RequestTimeout , "Request timeout"},
+        { ErrorCode.InternalError , "Internal error"}
+    };
+
+    private static double? ValidateErrorRate(double? rate)
+    {
+        if (rate > 1 || rate < 0)
+        {
+            throw new ArgumentException("Error rate must be between 0 and 1.");
+        }
+
+        return rate;
+    }
+
+    private readonly double _throwErrorThreshold = ValidateErrorRate(errorRate) ?? 0.1;
+    private readonly bool _varyErrorTypes = varyErrorTypes ?? false;
+    private Error? _lastError;
+
+    public Task<AuthResponse> AuthAsync(AuthRequest request)
+    {
+        return CallImplementation(x => x.AuthAsync(request));
+    }
+
+    public Task<SignResponse> SignAsync(SignRequest request)
+    {
+        return CallImplementation(x => x.SignAsync(request));
+    }
+
+    public Task<PhoneAuthResponse> PhoneAuthAsync(PhoneAuthRequest request)
+    {
+        return CallImplementation(x => x.PhoneAuthAsync(request));
+    }
+
+    public Task<PhoneSignResponse> PhoneSignAsync(PhoneSignRequest request)
+    {
+        return CallImplementation(x => x.PhoneSignAsync(request));
+    }
+
+    public Task<CollectResponse> CollectAsync(CollectRequest request)
+    {
+        return CallImplementation(x => x.CollectAsync(request));
+    }
+
+    public Task<CancelResponse> CancelAsync(CancelRequest request)
+    {
+        return CallImplementation(x => x.CancelAsync(request));
+    }
+
+    private async Task<TResponse> CallImplementation<TResponse>(Func<IBankIdAppApiClient, Task<TResponse>> call)
+    where TResponse : class
+    {
+        if (ShouldThrowError())
+        {
+            // If _lastError is null, get a random error
+            _lastError ??= GetRandomError();
+
+            // If varyErrorTypes is true, the error type will vary between requests
+            if (_varyErrorTypes)
+            {
+                _lastError = GetRandomError();
+            }
+
+            throw new BankIdApiException(
+                _lastError,
+                new HttpRequestException("Unknown"));
+        }
+
+        var result = await call(decorated);
+
+        return result;
+    }
+
+    private bool ShouldThrowError()
+    {
+        var r = new Random();
+        var result = r.NextDouble() < _throwErrorThreshold;
+        return result;
+    }
+
+    private Error GetRandomError()
+    {
+        var r = new Random();
+        var error = _errors.ElementAt(r.Next(0, _errors.Count));
+        return new Error(error.Key.ToString(), error.Value);
+    }
+
+}

--- a/src/ActiveLogin.Authentication.BankId.Core/Events/Infrastructure/BankIdDebugEventListener.cs
+++ b/src/ActiveLogin.Authentication.BankId.Core/Events/Infrastructure/BankIdDebugEventListener.cs
@@ -1,6 +1,8 @@
+using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
+using ActiveLogin.Authentication.BankId.Api;
 using ActiveLogin.Identity.Swedish;
 
 using Microsoft.Extensions.Logging;
@@ -24,6 +26,7 @@ public class BankIdDebugEventListener : IBankIdEventListener
 
         _serializerOptions.Converters.Add(new JsonStringEnumConverter());
         _serializerOptions.Converters.Add(new PersonalIdentityNumberJsonConverter());
+        _serializerOptions.Converters.Add(new BankIdApiExceptionJsonConverter());
     }
 
     public Task HandleAsync(BankIdEvent bankIdEvent)
@@ -61,5 +64,44 @@ public class BankIdDebugEventListener : IBankIdEventListener
             PersonalIdentityNumber personalIdentityNumberValue,
             JsonSerializerOptions options) =>
             writer.WriteStringValue(personalIdentityNumberValue.To12DigitString());
+    }
+
+    // This converter is used to serialize BankIdApiException to JSON.
+    // It serializes all properties of the exception, except for properties
+    // of type "Type" and properties of types in the System.Reflection namespace.
+    // Otherwise, this will fail when serialization and deserialization
+    // with "'System.Reflection.MethodBase' instances are not supported. Path: $.TargetSite."
+    private class BankIdApiExceptionJsonConverter : JsonConverter<BankIdApiException>
+    {
+        public override BankIdApiException Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options) =>
+            throw new NotImplementedException();
+        public override void Write(
+            Utf8JsonWriter writer,
+            BankIdApiException exception,
+            JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+            var exceptionType = exception.GetType();
+            writer.WriteString("ClassName", exceptionType.FullName);
+            var properties = exceptionType.GetProperties()
+                .Where(e => e.PropertyType != typeof(Type))
+                .Where(e => e.PropertyType.Namespace != typeof(MemberInfo).Namespace)
+                .ToList();
+            foreach (var property in properties)
+            {
+                var propertyValue = property.GetValue(exception, null);
+                if (options.DefaultIgnoreCondition == JsonIgnoreCondition.WhenWritingNull && propertyValue == null)
+                {
+                    continue;
+                }
+
+                writer.WritePropertyName(property.Name);
+                JsonSerializer.Serialize(writer, propertyValue, property.PropertyType, options);
+            }
+            writer.WriteEndObject();
+        }
     }
 }

--- a/src/ActiveLogin.Authentication.BankId.Core/IBankIdBuilderExtensions.cs
+++ b/src/ActiveLogin.Authentication.BankId.Core/IBankIdBuilderExtensions.cs
@@ -1,6 +1,7 @@
 using System.Security.Cryptography.X509Certificates;
 
 using ActiveLogin.Authentication.BankId.Api;
+using ActiveLogin.Authentication.BankId.Api.Models;
 using ActiveLogin.Authentication.BankId.Core.Certificate;
 using ActiveLogin.Authentication.BankId.Core.CertificatePolicies;
 using ActiveLogin.Authentication.BankId.Core.Cryptography;
@@ -9,6 +10,7 @@ using ActiveLogin.Authentication.BankId.Core.Launcher;
 using ActiveLogin.Authentication.BankId.Core.ResultStore;
 
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace ActiveLogin.Authentication.BankId.Core;
 public static class IBankIdBuilderExtensions
@@ -266,6 +268,43 @@ public static class IBankIdBuilderExtensions
             x => new BankIdSimulatedAppApiClient(givenName, surname, personalIdentityNumber),
             x => new BankIdSimulatedVerifyApiClient(givenName, surname, personalIdentityNumber)
         );
+    }
+
+    /// <summary>
+    /// Add simulated API errors to the BankID API client.
+    /// </summary>
+    /// <param name="builder"></param>
+    /// <param name="errorRate">Error percentage</param>
+    /// <param name="errors">Predefined dictionary of errors (ErrorCode, Error Message)</param>
+    /// <param name="varyErrorTypes">If true, the error type will vary between requests</param>
+    /// <returns></returns>
+    public static IBankIdBuilder AddSimulatedApiErrors(this IBankIdBuilder builder,
+        double? errorRate = null,
+        Dictionary<ErrorCode, string>? errors = null,
+        bool? varyErrorTypes = null)
+    {
+        // Make sure there is only one implementation of IBankIdAppApiClient
+        switch (builder.Services.Count(s => s.ServiceType == typeof(IBankIdAppApiClient)))
+        {
+            case 0:
+                throw new InvalidOperationException("No IBankIdAppApiClient implementation found in the service collection.");
+            case > 1:
+                throw new InvalidOperationException("Multiple IBankIdAppApiClient implementations found in the service collection. Only one implementation is allowed.");
+        }
+
+        // Decorate the original service with the simulated error decorator
+        var original = builder.Services.Single(x => x.ServiceType == typeof(IBankIdAppApiClient));
+        builder.Services.Remove(original);
+        builder.Services.Add(
+            new ServiceDescriptor(original.ServiceType, (x) =>
+                {
+                    var originalServiceFactory = original.ImplementationFactory?.Invoke(x) as IBankIdAppApiClient;
+                    return new BankIdErrorSimulatedApiClientDecorator(
+                        originalServiceFactory!, errorRate, errors, varyErrorTypes);
+            },
+            original.Lifetime));
+
+        return builder;
     }
 
     private static IBankIdBuilder UseSimulatedEnvironment(this IBankIdBuilder builder, Func<IServiceProvider, IBankIdAppApiClient> bankIdSimulatedAppApiClient, Func<IServiceProvider, IBankIdVerifyApiClient> bankIdSimulatedVerifyApiClient)

--- a/test/ActiveLogin.Authentication.BankId.Api.Test/ActiveLogin.Authentication.BankId.Api.Test.csproj
+++ b/test/ActiveLogin.Authentication.BankId.Api.Test/ActiveLogin.Authentication.BankId.Api.Test.csproj
@@ -4,6 +4,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="AutoFixture" Version="4.18.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="xunit" Version="2.9.2" />

--- a/test/ActiveLogin.Authentication.BankId.Api.Test/BankIdErrorSimulatedAppApiClientDecorator_Tests.cs
+++ b/test/ActiveLogin.Authentication.BankId.Api.Test/BankIdErrorSimulatedAppApiClientDecorator_Tests.cs
@@ -1,0 +1,187 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+using ActiveLogin.Authentication.BankId.Api.Models;
+
+using AutoFixture;
+
+using Moq;
+
+using Xunit;
+
+namespace ActiveLogin.Authentication.BankId.Api.Test;
+
+public class BankIdErrorSimulatedApiClientDecoratorTests
+{
+    private readonly Fixture _fixture = new Fixture();
+    private readonly Mock<IBankIdAppApiClient> _apiClientMock = new();
+    
+
+    private BankIdErrorSimulatedApiClientDecorator CreateSut(double errorRate, Dictionary<ErrorCode, string> errors, bool varyErrorType)
+    {
+        var apiClient = _apiClientMock.Object;
+        return new BankIdErrorSimulatedApiClientDecorator(apiClient, errorRate, errors, varyErrorType);
+    }
+
+    private Dictionary<ErrorCode, string> GenerateErrors(params ErrorCode[] errorCodes)
+    {
+        if (errorCodes.Length == 0)
+        {
+            errorCodes = [ErrorCode.AlreadyInProgress, ErrorCode.Maintenance, ErrorCode.RequestTimeout, ErrorCode.InternalError];
+        }
+
+        return errorCodes.ToDictionary(
+            errorCode => errorCode,
+            errorCode => errorCode.ToString());
+    }
+
+    [Fact]
+    public async Task Returns_Same_Error()
+    {
+        // Arrange
+        var sut = CreateSut(
+            1,
+            GenerateErrors(ErrorCode.InternalError, ErrorCode.Maintenance),
+            false);
+
+        var exceptions = new List<BankIdApiException>();
+
+        // Act
+        for (var i = 0; i < 10; i++)
+        {
+            exceptions.Add(await Assert.ThrowsAsync<BankIdApiException>(() =>
+                sut.AuthAsync(_fixture.Build<AuthRequest>().Create())));
+        }
+
+        // Assert - That the error is the same for each sut call
+        var errorCode = exceptions.First().ErrorCode;
+        Assert.All(exceptions, exception =>
+        {
+            Assert.Equal(errorCode, exception.ErrorCode);
+        });
+
+    }
+
+    [Fact]
+    public async Task Returns_Error_Variations()
+    {
+        // Arrange
+        var sut = CreateSut(
+            1,
+            GenerateErrors(ErrorCode.InternalError, ErrorCode.Maintenance),
+            true);
+
+        var exceptions = new List<BankIdApiException>();
+
+        // Act
+        for (var i = 0; i < 50; i++)
+        {
+            exceptions.Add(await Assert.ThrowsAsync<BankIdApiException>(() =>
+                sut.AuthAsync(_fixture.Build<AuthRequest>().Create())));
+        }
+
+        // Assert - That there are multiple error codes in the exceptions
+        var first = exceptions.First().ErrorCode;
+        Assert.False(exceptions.All(x => x.ErrorCode == exceptions.First().ErrorCode), "Errors do not vary.");
+    }
+
+    [Fact]
+    public async Task Returns_Only_Errors_From_List()
+    {
+        // Arrange
+        var allowedErrorCodes = new[] { ErrorCode.InternalError, ErrorCode.Maintenance, ErrorCode.TooManyRequests };
+        var sut = CreateSut(
+            1,
+            GenerateErrors(allowedErrorCodes),
+            true);
+
+        var exceptions = new List<BankIdApiException>();
+
+        // Act
+        for (var i = 0; i < 50; i++)
+        {
+            exceptions.Add(await Assert.ThrowsAsync<BankIdApiException>(() =>
+                sut.AuthAsync(_fixture.Build<AuthRequest>().Create())));
+        }
+
+        // Assert - That there are only allowed error codes in the exceptions
+        Assert.All(exceptions, exception =>
+        {
+            Assert.Contains(exception.ErrorCode, allowedErrorCodes);
+        });
+
+    }
+
+    [Fact]
+    public async Task Can_Call_All_Decorated_Client_Methods()
+    {
+        // Arrange
+        var sut = CreateSut(0, new Dictionary<ErrorCode, string>(), false);
+
+        // Setup AutoFixture to use RP as CallInitiator
+        var phoneAuthRequest =
+            new PhoneAuthRequest(_fixture.Create<string>(), CallInitiator.RP, null, null, null, null);
+
+        var phoneSignRequest =
+                       new PhoneSignRequest(_fixture.Create<string>(), CallInitiator.RP, _fixture.Create<string>(), null, null, null);
+
+        // Act
+        await sut.AuthAsync(_fixture.Build<AuthRequest>().Create());
+        await sut.SignAsync(_fixture.Build<SignRequest>().Create());
+        await sut.PhoneAuthAsync(phoneAuthRequest);
+        await sut.PhoneSignAsync(phoneSignRequest);
+        await sut.CollectAsync(_fixture.Build<CollectRequest>().Create());
+        await sut.CancelAsync(_fixture.Build<CancelRequest>().Create());
+
+        // Assert
+        _apiClientMock.Verify(x => x.AuthAsync(It.IsAny<AuthRequest>()), Times.Once);
+        _apiClientMock.Verify(x => x.SignAsync(It.IsAny<SignRequest>()), Times.Once);
+        _apiClientMock.Verify(x => x.PhoneAuthAsync(It.IsAny<PhoneAuthRequest>()), Times.Once);
+        _apiClientMock.Verify(x => x.PhoneSignAsync(It.IsAny<PhoneSignRequest>()), Times.Once);
+        _apiClientMock.Verify(x => x.CollectAsync(It.IsAny<CollectRequest>()), Times.Once);
+        _apiClientMock.Verify(x => x.CancelAsync(It.IsAny<CancelRequest>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Decorator_Has_Correct_Error_Rate()
+    {
+        // Arrange
+        var requestCount = 1000;
+        var errorRate = 0.5;
+        var sut = CreateSut(errorRate, GenerateErrors(), true);
+
+        // Act
+        var errorCount = 0;
+        for (var i = 0; i < requestCount; i++)
+        {
+            try
+            {
+                await sut.AuthAsync(_fixture.Build<AuthRequest>().Create());
+            }
+            catch (BankIdApiException)
+            {
+                errorCount++;
+            }
+        }
+
+        // Assert
+        var actualErrorRate = (double)errorCount / requestCount;
+        Assert.True(Math.Abs(actualErrorRate - errorRate) < 0.1, $"Error rate was {actualErrorRate} but expected {errorRate}");
+    }
+
+    [Fact]
+    public void Throws_Exception_When_Error_Rate_Is_Invalid()
+    {
+        // Arrange
+        var errorRate = 1.1;
+        // Act
+        var ex = Assert.Throws<ArgumentException>(() => CreateSut(errorRate, GenerateErrors(), true));
+        // Assert
+        Assert.Equal("Error rate must be between 0 and 1.", ex.Message);
+    }
+    
+}

--- a/test/ActiveLogin.Authentication.BankId.AspNetCore.Test/ActiveLogin.Authentication.BankId.AspNetCore.Test.csproj
+++ b/test/ActiveLogin.Authentication.BankId.AspNetCore.Test/ActiveLogin.Authentication.BankId.AspNetCore.Test.csproj
@@ -6,6 +6,7 @@
 
     <ItemGroup>
         <PackageReference Include="AngleSharp" Version="1.1.2" />
+        <PackageReference Include="AutoFixture" Version="4.18.1" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.10" />
         <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.10" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />

--- a/test/ActiveLogin.Authentication.BankId.Core.Test/BankIdBuilder_Tests.cs
+++ b/test/ActiveLogin.Authentication.BankId.Core.Test/BankIdBuilder_Tests.cs
@@ -1,0 +1,33 @@
+using System;
+
+using ActiveLogin.Authentication.BankId.Api;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Xunit;
+
+namespace ActiveLogin.Authentication.BankId.Core.Test;
+public class BankIdBuilderTests
+{
+    [Fact]
+    public void AddSimulatedApiErrors_Throws_If_Multiple_IBankIdAppApiClient_Exists_In_ServiceCollection()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IBankIdAppApiClient, BankIdAppApiClient>();
+        services.AddSingleton<IBankIdAppApiClient, BankIdAppApiClient>();
+        var builder = new BankIdBuilder(services);
+        var exception = Assert.Throws<InvalidOperationException>(() => builder.AddSimulatedApiErrors());
+        Assert.Equal("Multiple IBankIdAppApiClient implementations found in the service collection. Only one implementation is allowed.", exception.Message);
+    }
+
+    [Fact]
+    public void AddSimulatedApiErrors_Throws_If_No_IBankIdAppApiClient_Exists_In_ServiceCollection()
+    {
+        var services = new ServiceCollection();
+        var builder = new BankIdBuilder(services);
+        var exception = Assert.Throws<InvalidOperationException>(() => builder.AddSimulatedApiErrors());
+        Assert.Equal("No IBankIdAppApiClient implementation found in the service collection.", exception.Message);
+
+    }
+
+}


### PR DESCRIPTION
This PR fixes #270.

New feature to simulate BankID API errors for development and testing.

#### PR Summary
Introduced functionality to simulate BankID API errors and added related documentation and tests.
- `bankid.md`: Documented how to simulate BankID API errors using `AddSimulatedBankIdApiError`.
- `BankIdErrorSimulatedApiClientDecorator.cs`: Added a decorator class to simulate errors from the BankID API.
- `IBankIdBuilderExtensions.cs`: Added an extension method to integrate simulated API errors into the BankID API client.
- `BankIdErrorSimulatedAppApiClientDecorator_Tests.cs`: Created tests for the error simulation decorator.
- `BankIdBuilder_Tests.cs`: Added tests to ensure proper handling of simulated API errors in the service collection.
