### PR TITLE
Feature/return risk

### DIFF
--- a/docs/articles/bankid.md
+++ b/docs/articles/bankid.md
@@ -473,6 +473,13 @@ BankId options allows you to set and override some options such as the below req
     // the transaction will be blocked. The risk indication requires that the endUserIp is correct.
     // An incorrect IP-address will result in legitimate transactions being blocked.
     options.BankIdAllowedRiskLevel = BankIdAllowedRiskLevel.Low;
+
+    // If this is set to true a risk indicator will be included in the collect response when the order completes.
+    // If a risk indicator is required for the order to complete, for example, if a risk requirement is applied,
+    // the returnRisk property is ignored, and a risk indicator is always included; otherwise a default value of
+    // false is used. The risk indication requires that the endUserIp is correct. Please note that the assessed
+    // risk will not be returned if the order was blocked, which may happen if a risk requirement is set.
+    options.BankIdReturnRisk = true;
 });
 ```
 
@@ -482,6 +489,7 @@ If you want to apply some options for all BankID schemes, you can do so by using
 .Configure(options =>
 {
     options.BankIdRequireMrtd = true;
+    options.BankIdReturnRisk = true;
 });
 ```
 
@@ -666,6 +674,22 @@ public class BankIdPinHintClaimsTransformer : IBankIdClaimsTransformer
 }
 ```
 
+#### Example: Add risk claim
+
+If the application whats to act on the evaluated risk level for the transaction it could be extracted from the completion data returned by BankID.
+
+```csharp
+public class BankIdTxnClaimsTransformer : IBankIdClaimsTransformer
+{
+    public Task TransformClaims(BankIdClaimsTransformationContext context)
+    {
+        if (context.BankIdCompletionData != null && context.BankIdCompletionData.Risk != null)
+            context.AddClaim("user_risk", context.BankIdCompletionData.Risk);
+
+        return Task.CompletedTask;
+    }
+}
+```
 
 ### Return URL for cancellation
 

--- a/docs/articles/bankid.md
+++ b/docs/articles/bankid.md
@@ -77,7 +77,7 @@ The root CA-certificates specified in _BankID Relying Party Guidelines_ (#7 for 
 It is expected that you have a basic understanding of how [ASP.NET](https://docs.microsoft.com/en-us/aspnet/core/), [ASP.NET MVC](https://docs.microsoft.com/en-us/aspnet/core/mvc/overview) and [ASP.NET Authentication](https://docs.microsoft.com/en-us/aspnet/core/security/authentication/identity) works before getting started.
 
 
-Active Login is designed to make it very easy to get started with BankID, but in the end you are responsible for making sure that you are complient with the technical guidelines and/or legal agreements.
+Active Login is designed to make it very easy to get started with BankID, but in the end you are responsible for making sure that you are compliant with the technical guidelines and/or legal agreements.
 
 Therefore, before you start using Active Login, please read the documentation relevant to your needs. This will also make sure you understand the concepts better.
 

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Auth/BankIdAuthHandler.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Auth/BankIdAuthHandler.cs
@@ -163,6 +163,7 @@ public class BankIdAuthHandler : RemoteAuthenticationHandler<BankIdAuthOptions>
             Options.BankIdSameDevice,
             Options.BankIdRequirePinCode,
             Options.BankIdRequireMrtd,
+            Options.BankIdReturnRisk,
             BankIdHandlerHelper.GetCancelReturnUrl(properties.Items),
             Options.StateCookie.Name ?? string.Empty
         );

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Auth/BankIdAuthOptions.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Auth/BankIdAuthOptions.cs
@@ -40,6 +40,15 @@ public class BankIdAuthOptions : RemoteAuthenticationOptions
     public BankIdAllowedRiskLevel BankIdAllowedRiskLevel { get; set; } = BankIdAllowedRiskLevel.NoRiskLevel;
 
     /// <summary>
+    /// If this is set to true a risk indicator will be included in the collect response when the order completes.
+    /// If a risk indicator is required for the order to complete, for example, if a risk requirement is applied,
+    /// the returnRisk property is ignored, and a risk indicator is always included; otherwise a default value of
+    /// false is used. The risk indication requires that the endUserIp is correct. Please note that the assessed
+    /// risk will not be returned if the order was blocked, which may happen if a risk requirement is set.
+    /// </summary>
+    public bool BankIdReturnRisk { get; set; } = false;
+
+    /// <summary>
     /// Auto launch the BankID app on the current device.
     /// </summary>
     internal bool BankIdSameDevice { get; set; } = false;

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/DataProtection/Serialization/BankIdUiOptionsSerializer.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/DataProtection/Serialization/BankIdUiOptionsSerializer.cs
@@ -15,6 +15,7 @@ internal class BankIdUiOptionsSerializer : BankIdDataSerializer<BankIdUiOptions>
         writer.Write(model.SameDevice);
         writer.Write(model.RequirePinCode);
         writer.Write(model.RequireMrtd);
+        writer.Write(model.ReturnRisk);
         writer.Write(model.CancelReturnUrl);
         writer.Write(model.StateCookieName);
     }
@@ -35,6 +36,7 @@ internal class BankIdUiOptionsSerializer : BankIdDataSerializer<BankIdUiOptions>
         return new BankIdUiOptions(
             certificatePolicies,
             riskLevel,
+            reader.ReadBoolean(),
             reader.ReadBoolean(),
             reader.ReadBoolean(),
             reader.ReadBoolean(),

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Models/BankIdUiOptions.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Models/BankIdUiOptions.cs
@@ -11,6 +11,7 @@ public class BankIdUiOptions
         bool sameDevice,
         bool requirePinCode,
         bool requireMrtd,
+        bool returnRisk,
         string cancelReturnUrl,
         string stateCookieName)
     {
@@ -19,6 +20,7 @@ public class BankIdUiOptions
         SameDevice = sameDevice;
         RequirePinCode = requirePinCode;
         RequireMrtd = requireMrtd;
+        ReturnRisk = returnRisk;
         CancelReturnUrl = cancelReturnUrl;
         StateCookieName = stateCookieName;
     }
@@ -30,6 +32,8 @@ public class BankIdUiOptions
     public bool RequirePinCode { get; }
 
     public bool RequireMrtd { get; }
+
+    public bool ReturnRisk { get; }
 
     public BankIdAllowedRiskLevel AllowedRiskLevel { get; }
 

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Models/BankIdUiOptionsExtensions.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Models/BankIdUiOptionsExtensions.cs
@@ -9,6 +9,7 @@ public static class BankIdUiOptionsExtensions
         options.AllowedRiskLevel,
         options.SameDevice,
         options.RequirePinCode,
-        options.RequireMrtd
+        options.RequireMrtd,
+        options.ReturnRisk
     );
 }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Sign/BankIdSignOptions.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Sign/BankIdSignOptions.cs
@@ -24,6 +24,15 @@ public class BankIdSignOptions
     public bool BankIdRequireMrtd { get; set; } = false;
 
     /// <summary>
+    /// If this is set to true a risk indicator will be included in the collect response when the order completes.
+    /// If a risk indicator is required for the order to complete, for example, if a risk requirement is applied,
+    /// the returnRisk property is ignored, and a risk indicator is always included; otherwise a default value of
+    /// false is used. The risk indication requires that the endUserIp is correct. Please note that the assessed
+    /// risk will not be returned if the order was blocked, which may happen if a risk requirement is set.
+    /// </summary>
+    public bool BankIdReturnRisk { get; set; } = false;
+
+    /// <summary>
     /// Set the acceptable risk level for the transaction. If the risk is higher than the specified level,
     /// the transaction will be blocked. The risk indication requires that the endUserIp is correct.
     /// An incorrect IP-address will result in legitimate transactions being blocked.

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Sign/BankIdSignService.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Sign/BankIdSignService.cs
@@ -67,6 +67,7 @@ public class BankIdSignService : IBankIdSignService
             options.BankIdSameDevice,
             options.BankIdRequirePinCode,
             options.BankIdRequireMrtd,
+            options.BankIdReturnRisk,
             BankIdHandlerHelper.GetCancelReturnUrl(properties.Items),
             options.StateCookie.Name ?? string.Empty
         );

--- a/src/ActiveLogin.Authentication.BankId.Core/Flow/BankIdFlowService.cs
+++ b/src/ActiveLogin.Authentication.BankId.Core/Flow/BankIdFlowService.cs
@@ -115,6 +115,8 @@ public class BankIdFlowService : IBankIdFlowService
         var requirePinCode = resolvedRequirements.RequirePinCode ?? flowOptions.RequirePinCode;
         var requestRequirement = new Requirement(resolvedCertificatePolicies, resolvedRiskLevel, requirePinCode, requireMrtd, requiredPersonalIdentityNumber?.To12DigitString());
 
+        var returnRisk = flowOptions.ReturnRisk;
+
         var authRequestContext = new BankIdAuthRequestContext(endUserIp, requestRequirement);
         var userData = await _bankIdAuthUserDataResolver.GetUserDataAsync(authRequestContext);
         var (webDeviceData, appDeviceData) = GetDeviceData();
@@ -126,7 +128,7 @@ public class BankIdFlowService : IBankIdFlowService
             userData.UserNonVisibleData,
             userData.UserVisibleDataFormat,
             returnUrl: null,
-            returnRisk: null,
+            returnRisk: returnRisk,
             web: webDeviceData,
             app: appDeviceData
         );
@@ -181,6 +183,9 @@ public class BankIdFlowService : IBankIdFlowService
         var requireMrtd = bankIdSignData.RequireMrtd ?? flowOptions.RequireMrtd;
         var requirePinCode = bankIdSignData.RequirePinCode ?? flowOptions.RequirePinCode;
         var requestRequirement = new Requirement(resolvedCertificatePolicies, resolvedRiskLevel, requirePinCode, requireMrtd, requiredPersonalIdentityNumber?.To12DigitString());
+
+        var returnRisk = flowOptions.ReturnRisk;
+
         var (webDeviceData, appDeviceData) = GetDeviceData();
 
         return new SignRequest(
@@ -190,7 +195,7 @@ public class BankIdFlowService : IBankIdFlowService
             userVisibleDataFormat: bankIdSignData.UserVisibleDataFormat,
             requirement: requestRequirement,
             returnUrl: null,
-            returnRisk: null,
+            returnRisk: returnRisk,
             web: webDeviceData,
             app: appDeviceData
         );

--- a/src/ActiveLogin.Authentication.BankId.Core/Models/BankIdFlowOptions.cs
+++ b/src/ActiveLogin.Authentication.BankId.Core/Models/BankIdFlowOptions.cs
@@ -12,6 +12,7 @@ public class BankIdFlowOptions
         bool sameDevice,
         bool requirePinCode,
         bool requireMrtd,
+        bool requireRisk,
         PersonalIdentityNumber? requiredPersonalIdentityNumber = null)
     {
         CertificatePolicies = certificatePolicies;
@@ -19,6 +20,7 @@ public class BankIdFlowOptions
         SameDevice = sameDevice;
         RequirePinCode = requirePinCode;
         RequireMrtd = requireMrtd;
+        ReturnRisk = requireRisk;
         RequiredPersonalIdentityNumber = requiredPersonalIdentityNumber;
     }
 
@@ -29,6 +31,8 @@ public class BankIdFlowOptions
     public bool RequirePinCode { get; }
 
     public bool RequireMrtd { get; }
+
+    public bool ReturnRisk {  get; }
 
     public BankIdAllowedRiskLevel AllowedRiskLevel { get; }
 

--- a/test/ActiveLogin.Authentication.BankId.AspNetCore.Test/BankId_UiAuth_Tests.cs
+++ b/test/ActiveLogin.Authentication.BankId.AspNetCore.Test/BankId_UiAuth_Tests.cs
@@ -46,7 +46,7 @@ public class BankId_UiAuth_Tests : BankId_Ui_Tests_Base
         _bankIdUiOptionsProtector = new Mock<IBankIdUiOptionsProtector>();
         _bankIdUiOptionsProtector
             .Setup(protector => protector.Unprotect(It.IsAny<string>()))
-            .Returns(new BankIdUiOptions(new List<BankIdCertificatePolicy>(), Core.Risk.BankIdAllowedRiskLevel.Low, false, false, false, "/", DefaultStateCookieName));
+            .Returns(new BankIdUiOptions(new List<BankIdCertificatePolicy>(), Core.Risk.BankIdAllowedRiskLevel.Low, false, false, false, false, "/", DefaultStateCookieName));
         _bankIdUiOptionsProtector
             .Setup(protector => protector.Protect(It.IsAny<BankIdUiOptions>()))
             .Returns("Ignored");
@@ -220,7 +220,7 @@ public class BankId_UiAuth_Tests : BankId_Ui_Tests_Base
     public async Task Init_Returns_Ui_With_Resolved_Cancel_Url()
     {
         // Arrange
-        var options = new BankIdUiOptions(new List<BankIdCertificatePolicy>(), Core.Risk.BankIdAllowedRiskLevel.Low, true, false, false, "~/cru", DefaultStateCookieName);
+        var options = new BankIdUiOptions(new List<BankIdCertificatePolicy>(), Core.Risk.BankIdAllowedRiskLevel.Low, true, false, false, false, "~/cru", DefaultStateCookieName);
         _bankIdUiOptionsProtector
             .Setup(protector => protector.Unprotect(It.IsAny<string>()))
             .Returns(options);
@@ -368,7 +368,7 @@ public class BankId_UiAuth_Tests : BankId_Ui_Tests_Base
     {
         // Arrange mocks
         var autoLaunchOptions =
-            new BankIdUiOptions(new List<BankIdCertificatePolicy>(), Core.Risk.BankIdAllowedRiskLevel.Low, true, false, false, string.Empty, DefaultStateCookieName);
+            new BankIdUiOptions(new List<BankIdCertificatePolicy>(), Core.Risk.BankIdAllowedRiskLevel.Low, true, false, false, false, string.Empty, DefaultStateCookieName);
         var mockProtector = new Mock<IBankIdUiOptionsProtector>();
         mockProtector
             .Setup(protector => protector.Unprotect(It.IsAny<string>()))
@@ -424,7 +424,7 @@ public class BankId_UiAuth_Tests : BankId_Ui_Tests_Base
     {
         // Arrange mocks
         var autoLaunchOptions =
-            new BankIdUiOptions(new List<BankIdCertificatePolicy>(), Core.Risk.BankIdAllowedRiskLevel.Low, false, false, false, string.Empty, DefaultStateCookieName);
+            new BankIdUiOptions(new List<BankIdCertificatePolicy>(), Core.Risk.BankIdAllowedRiskLevel.Low, false, false, false, false, string.Empty, DefaultStateCookieName);
         var mockProtector = new Mock<IBankIdUiOptionsProtector>();
         mockProtector
             .Setup(protector => protector.Unprotect(It.IsAny<string>()))
@@ -480,7 +480,7 @@ public class BankId_UiAuth_Tests : BankId_Ui_Tests_Base
     {
         // Arrange mocks
         var autoLaunchOptions =
-            new BankIdUiOptions(new List<BankIdCertificatePolicy>(), Core.Risk.BankIdAllowedRiskLevel.Low, false, false, false, string.Empty, DefaultStateCookieName);
+            new BankIdUiOptions(new List<BankIdCertificatePolicy>(), Core.Risk.BankIdAllowedRiskLevel.Low, false, false, false, false, string.Empty, DefaultStateCookieName);
         _bankIdUiOptionsProtector
             .Setup(protector => protector.Unprotect(It.IsAny<string>()))
             .Returns(autoLaunchOptions);
@@ -526,7 +526,7 @@ public class BankId_UiAuth_Tests : BankId_Ui_Tests_Base
     {
         // Arrange mocks
         var autoLaunchOptions =
-            new BankIdUiOptions(new List<BankIdCertificatePolicy>(), Core.Risk.BankIdAllowedRiskLevel.Low, false, false, false, string.Empty, DefaultStateCookieName);
+            new BankIdUiOptions(new List<BankIdCertificatePolicy>(), Core.Risk.BankIdAllowedRiskLevel.Low, false, false, false, false, string.Empty, DefaultStateCookieName);
         _bankIdUiOptionsProtector
             .Setup(protector => protector.Unprotect(It.IsAny<string>()))
             .Returns(autoLaunchOptions);

--- a/test/ActiveLogin.Authentication.BankId.AspNetCore.Test/BankId_UiSign_Tests.cs
+++ b/test/ActiveLogin.Authentication.BankId.AspNetCore.Test/BankId_UiSign_Tests.cs
@@ -49,7 +49,7 @@ public class BankId_UiSign_Tests : BankId_Ui_Tests_Base
         _bankIdUiOptionsProtector = new Mock<IBankIdUiOptionsProtector>();
         _bankIdUiOptionsProtector
             .Setup(protector => protector.Unprotect(It.IsAny<string>()))
-            .Returns(new BankIdUiOptions(new List<BankIdCertificatePolicy>(), Core.Risk.BankIdAllowedRiskLevel.Low, false, false, false, "/", DefaultStateCookieName));
+            .Returns(new BankIdUiOptions(new List<BankIdCertificatePolicy>(), Core.Risk.BankIdAllowedRiskLevel.Low, false, false, false, false, "/", DefaultStateCookieName));
         _bankIdUiOptionsProtector
             .Setup(protector => protector.Protect(It.IsAny<BankIdUiOptions>()))
             .Returns("Ignored");
@@ -222,7 +222,7 @@ public class BankId_UiSign_Tests : BankId_Ui_Tests_Base
     public async Task SignInit_Returns_Ui_With_Resolved_Cancel_Url()
     {
         // Arrange
-        var options = new BankIdUiOptions(new List<BankIdCertificatePolicy>(), Core.Risk.BankIdAllowedRiskLevel.Low, true, false, false, "~/cru", DefaultStateCookieName);
+        var options = new BankIdUiOptions(new List<BankIdCertificatePolicy>(), Core.Risk.BankIdAllowedRiskLevel.Low, true, false, false, false, "~/cru", DefaultStateCookieName);
         _bankIdUiOptionsProtector
             .Setup(protector => protector.Unprotect(It.IsAny<string>()))
             .Returns(options);
@@ -367,7 +367,7 @@ public class BankId_UiSign_Tests : BankId_Ui_Tests_Base
     public async Task AutoLaunch_Sets_Correct_RedirectUri()
     {
         // Arrange mocks
-        var autoLaunchOptions = new BankIdUiOptions(new List<BankIdCertificatePolicy>(), Core.Risk.BankIdAllowedRiskLevel.Low, true, false, false, string.Empty, DefaultStateCookieName);
+        var autoLaunchOptions = new BankIdUiOptions(new List<BankIdCertificatePolicy>(), Core.Risk.BankIdAllowedRiskLevel.Low, true, false, false, false, string.Empty, DefaultStateCookieName);
         var mockProtector = new Mock<IBankIdUiOptionsProtector>();
         mockProtector
             .Setup(protector => protector.Unprotect(It.IsAny<string>()))
@@ -420,7 +420,7 @@ public class BankId_UiSign_Tests : BankId_Ui_Tests_Base
     public async Task Api_Always_Returns_CamelCase_Json_For_Http200Ok()
     {
         // Arrange mocks
-        var autoLaunchOptions = new BankIdUiOptions(new List<BankIdCertificatePolicy>(), Core.Risk.BankIdAllowedRiskLevel.Low, false, false, false, string.Empty, DefaultStateCookieName);
+        var autoLaunchOptions = new BankIdUiOptions(new List<BankIdCertificatePolicy>(), Core.Risk.BankIdAllowedRiskLevel.Low, false, false, false, false, string.Empty, DefaultStateCookieName);
 
         var mockProtector = new Mock<IBankIdUiOptionsProtector>();
         mockProtector
@@ -483,7 +483,7 @@ public class BankId_UiSign_Tests : BankId_Ui_Tests_Base
     public async Task Api_Always_Returns_CamelCase_Json_For_Http400BadRequest()
     {
         // Arrange mocks
-        var autoLaunchOptions = new BankIdUiOptions(new List<BankIdCertificatePolicy>(), Core.Risk.BankIdAllowedRiskLevel.Low, false, false, false, string.Empty, DefaultStateCookieName);
+        var autoLaunchOptions = new BankIdUiOptions(new List<BankIdCertificatePolicy>(), Core.Risk.BankIdAllowedRiskLevel.Low, false, false, false, false, string.Empty, DefaultStateCookieName);
         _bankIdUiOptionsProtector
             .Setup(protector => protector.Unprotect(It.IsAny<string>()))
             .Returns(autoLaunchOptions);
@@ -528,7 +528,7 @@ public class BankId_UiSign_Tests : BankId_Ui_Tests_Base
     public async Task Cancel_Calls_CancelApi()
     {
         // Arrange mocks
-        var autoLaunchOptions = new BankIdUiOptions(new List<BankIdCertificatePolicy>(), Core.Risk.BankIdAllowedRiskLevel.Low, false, false, false, string.Empty, DefaultStateCookieName);
+        var autoLaunchOptions = new BankIdUiOptions(new List<BankIdCertificatePolicy>(), Core.Risk.BankIdAllowedRiskLevel.Low, false, false, false, false, string.Empty, DefaultStateCookieName);
         _bankIdUiOptionsProtector
             .Setup(protector => protector.Unprotect(It.IsAny<string>()))
             .Returns(autoLaunchOptions);


### PR DESCRIPTION
This PR fixes

#486  Implement return risk for Auth and Sign

High level overview of this PR:

- Add possibility to make BankID return evaluated risk level for Auth and Sign requests.