### PR TITLE
Revert to .Net 8 since certificate issues in .Net 9 is not yet resolved.

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "9.0.102",
+        "version": "8.0.405",
         "rollForward": "latestFeature"
     }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "8.0.405",
+        "version": "8.0.407",
         "rollForward": "latestFeature"
     }
 }

--- a/samples/IdentityServer.ClientSample/IdentityServer.ClientSample.csproj
+++ b/samples/IdentityServer.ClientSample/IdentityServer.ClientSample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
@@ -18,7 +18,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="9.0.2" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.10" />
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
     </ItemGroup>
 

--- a/samples/IdentityServer.ServerSample/IdentityServer.ServerSample.csproj
+++ b/samples/IdentityServer.ServerSample/IdentityServer.ServerSample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
@@ -19,9 +19,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Duende.IdentityServer" Version="7.1.0" />
+        <PackageReference Include="Duende.IdentityServer" Version="7.0.8" />
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="9.0.2" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.10" />
         <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.22.0" />
     </ItemGroup>
 

--- a/samples/Phone.ConsoleSample/Phone.ConsoleSample.csproj
+++ b/samples/Phone.ConsoleSample/Phone.ConsoleSample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
@@ -20,9 +20,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.2" />
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.2" />
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.2" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/Standalone.MvcSample/Standalone.MvcSample.csproj
+++ b/samples/Standalone.MvcSample/Standalone.MvcSample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/src/ActiveLogin.Authentication.BankId.Api/ActiveLogin.Authentication.BankId.Api.csproj
+++ b/src/ActiveLogin.Authentication.BankId.Api/ActiveLogin.Authentication.BankId.Api.csproj
@@ -13,7 +13,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
-        <PackageReference Include="System.Text.Json" Version="9.0.2" />
+        <PackageReference Include="System.Text.Json" Version="8.0.5" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/ActiveLogin.Authentication.BankId.AspNetCore.csproj
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/ActiveLogin.Authentication.BankId.AspNetCore.csproj
@@ -14,6 +14,8 @@
 
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
+        <PackageReference Include="ActiveLogin.Identity.Swedish" Version="3.0.0" />
     </ItemGroup>
 
     <ItemGroup>
@@ -52,7 +54,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="5.7.3">
+        <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="5.6.2">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/ActiveLogin.Authentication.BankId.AzureKeyVault/ActiveLogin.Authentication.BankId.AzureKeyVault.csproj
+++ b/src/ActiveLogin.Authentication.BankId.AzureKeyVault/ActiveLogin.Authentication.BankId.AzureKeyVault.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Azure.Identity" Version="1.13.2" />
+        <PackageReference Include="Azure.Identity" Version="1.13.0" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
     </ItemGroup>
 

--- a/src/ActiveLogin.Authentication.BankId.AzureKeyVault/AzureKeyVaultCertificateClient.cs
+++ b/src/ActiveLogin.Authentication.BankId.AzureKeyVault/AzureKeyVaultCertificateClient.cs
@@ -62,7 +62,9 @@ internal class AzureKeyVaultCertificateClient(SecretClient secretClient)
 
     private static X509Certificate2 GetX509Certificate2(byte[] certificate)
     {
-        return X509CertificateLoader.LoadPkcs12Collection(certificate, null, X509KeyStorageFlags.MachineKeySet)
-            .First(x => x.HasPrivateKey);
+        var exportedCertCollection = new X509Certificate2Collection();
+        exportedCertCollection.Import(certificate, null, X509KeyStorageFlags.MachineKeySet);
+
+        return exportedCertCollection.Cast<X509Certificate2>().First(x => x.HasPrivateKey);
     }
 }

--- a/src/ActiveLogin.Authentication.BankId.Core/ActiveLogin.Authentication.BankId.Core.csproj
+++ b/src/ActiveLogin.Authentication.BankId.Core/ActiveLogin.Authentication.BankId.Core.csproj
@@ -15,9 +15,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Bcl.Cryptography" Version="9.0.2" />
-        <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.2" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.2" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
     </ItemGroup>
 

--- a/src/ActiveLogin.Authentication.BankId.Core/BankIdCertificates.cs
+++ b/src/ActiveLogin.Authentication.BankId.Core/BankIdCertificates.cs
@@ -35,10 +35,12 @@ internal static class BankIdCertificates
         var certStream = GetBankIdResourceStream(filename);
         using var memory = new MemoryStream((int)certStream.Length);
         certStream.CopyTo(memory);
+        if (password == null)
+        {
+            return new X509Certificate2(memory.ToArray());
+        }
 
-        return string.IsNullOrWhiteSpace(password)
-            ? X509CertificateLoader.LoadCertificate(memory.ToArray())
-            : X509CertificateLoader.LoadPkcs12(memory.ToArray(), password);
+        return new X509Certificate2(memory.ToArray(), password);
     }
 
     private static X509Certificate2 GetPemCertFromResourceStream(CertificateResource resource)

--- a/src/ActiveLogin.Authentication.BankId.Core/IBankIdBuilderExtensions.cs
+++ b/src/ActiveLogin.Authentication.BankId.Core/IBankIdBuilderExtensions.cs
@@ -84,7 +84,7 @@ public static class IBankIdBuilderExtensions
     /// <returns></returns>
     public static IBankIdBuilder UseRootCaCertificate(this IBankIdBuilder builder, string certificateFilePath)
     {
-        builder.UseRootCaCertificate(() => X509CertificateLoader.LoadCertificateFromFile(certificateFilePath));
+        builder.UseRootCaCertificate(() => new X509Certificate2(certificateFilePath));
 
         return builder;
     }
@@ -186,7 +186,7 @@ public static class IBankIdBuilderExtensions
     /// <param name="useBankIdClientCertificate">Use the BankID client certificate (for test) from the BankID documentation.</param>
     /// <param name="clientCertificateFormat">If using the BankID client certificate (for test). Select the preferred format p12, pem or pfx.</param>
     /// <returns></returns>
-    public static IBankIdBuilder UseTestEnvironment(this IBankIdBuilder builder, bool useBankIdRootCertificate = true, bool useBankIdClientCertificate = true, TestCertificateFormat clientCertificateFormat = TestCertificateFormat.P12)
+    public static IBankIdBuilder UseTestEnvironment(this IBankIdBuilder builder, bool useBankIdRootCertificate = true, bool useBankIdClientCertificate = true, TestCertificateFormat clientCertificateFormat = TestCertificateFormat.PFX)
     {
         builder.UseEnvironment(BankIdUrls.AppApiTestBaseUrl, BankIdUrls.VerifyApiTestBaseUrl, BankIdEnvironments.Test);
         builder.Services.AddTransient<IBankIdCertificatePolicyResolver, BankIdCertificatePolicyResolverForTest>();

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/test/ActiveLogin.Authentication.BankId.Api.Test/ActiveLogin.Authentication.BankId.Api.Test.csproj
+++ b/test/ActiveLogin.Authentication.BankId.Api.Test/ActiveLogin.Authentication.BankId.Api.Test.csproj
@@ -5,10 +5,10 @@
 
     <ItemGroup>
         <PackageReference Include="AutoFixture" Version="4.18.1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
         <PackageReference Include="Moq" Version="4.20.72" />
-        <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+        <PackageReference Include="xunit" Version="2.9.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>

--- a/test/ActiveLogin.Authentication.BankId.AspNetCore.Test/ActiveLogin.Authentication.BankId.AspNetCore.Test.csproj
+++ b/test/ActiveLogin.Authentication.BankId.AspNetCore.Test/ActiveLogin.Authentication.BankId.AspNetCore.Test.csproj
@@ -1,18 +1,18 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
     </PropertyGroup>
 
 
     <ItemGroup>
-        <PackageReference Include="AngleSharp" Version="1.2.0" />
+        <PackageReference Include="AngleSharp" Version="1.1.2" />
         <PackageReference Include="AutoFixture" Version="4.18.1" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.2" />
-        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="9.0.2" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.10" />
+        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.10" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
         <PackageReference Include="Moq" Version="4.20.72" />
-        <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+        <PackageReference Include="xunit" Version="2.9.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>

--- a/test/ActiveLogin.Authentication.BankId.AzureKeyVault.Test/ActiveLogin.Authentication.BankId.AzureKeyVault.Test.csproj
+++ b/test/ActiveLogin.Authentication.BankId.AzureKeyVault.Test/ActiveLogin.Authentication.BankId.AzureKeyVault.Test.csproj
@@ -4,9 +4,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-        <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+        <PackageReference Include="xunit" Version="2.9.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/test/ActiveLogin.Authentication.BankId.Core.Test/ActiveLogin.Authentication.BankId.Core.Test.csproj
+++ b/test/ActiveLogin.Authentication.BankId.Core.Test/ActiveLogin.Authentication.BankId.Core.Test.csproj
@@ -5,11 +5,10 @@
 
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.2" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
         <PackageReference Include="Moq" Version="4.20.72" />
-        <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+        <PackageReference Include="xunit" Version="2.9.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>

--- a/test/ActiveLogin.Authentication.BankId.UAParser.Test/ActiveLogin.Authentication.BankId.UAParser.Test.csproj
+++ b/test/ActiveLogin.Authentication.BankId.UAParser.Test/ActiveLogin.Authentication.BankId.UAParser.Test.csproj
@@ -1,25 +1,25 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
+    <PropertyGroup>
 
-  </PropertyGroup>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+        <PackageReference Include="Moq" Version="4.20.72" />
+        <PackageReference Include="xunit" Version="2.9.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="6.0.2">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\ActiveLogin.Authentication.BankId.UAParser\ActiveLogin.Authentication.BankId.UAParser.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\ActiveLogin.Authentication.BankId.UAParser\ActiveLogin.Authentication.BankId.UAParser.csproj" />
+    </ItemGroup>
 
 </Project>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <LangVersion>latest</LangVersion>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 


### PR DESCRIPTION
Revert to .Net 8 since certificate issues in .Net 9 is not yet resolved. See issue #484.
