### PR TITLE
Fix/empty return url

### DIFF
--- a/src/ActiveLogin.Authentication.BankId.Core/Launcher/BankIdLauncher.cs
+++ b/src/ActiveLogin.Authentication.BankId.Core/Launcher/BankIdLauncher.cs
@@ -170,12 +170,10 @@ internal class BankIdLauncher : IBankIdLauncher
             BankIdSupportedDeviceBrowser.Chrome => IosChromeScheme,
             BankIdSupportedDeviceBrowser.Firefox => IosFirefoxScheme,
 
-            // Opens a new tab on app launch, so can't launch automatically
-            BankIdSupportedDeviceBrowser.Edge => string.Empty,
-            BankIdSupportedDeviceBrowser.Opera => string.Empty,
+            BankIdSupportedDeviceBrowser.Edge => NullRedirectUrl,
+            BankIdSupportedDeviceBrowser.Opera => NullRedirectUrl,
 
-            // Return empty string so user can go back manually, will catch unknown third party browsers
-            _ => string.Empty
+            _ => NullRedirectUrl
         };
     }
 


### PR DESCRIPTION
Sending string.Empty as RedirectUri to BankId is not supported, should be "null"