### PR TITLE
refactor and fix redirecturl to bankid

### DIFF
--- a/samples/Standalone.MvcSample/Program.cs
+++ b/samples/Standalone.MvcSample/Program.cs
@@ -17,6 +17,7 @@ using ActiveLogin.Authentication.BankId.UaParser;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.CookiePolicy;
 using Microsoft.AspNetCore.Localization;
+using ActiveLogin.Authentication.BankId.Core.Launcher;
 
 
 //
@@ -76,8 +77,8 @@ services
         bankId.UseQrCoderQrCodeGenerator();
         bankId.UseUaParserDeviceDetection();
 
-        bankId.AddCustomBrowserByUserAgent(userAgent => userAgent.Contains("Instagram"), "instagram://");
-        bankId.AddCustomBrowserByUserAgent(userAgent => userAgent.Contains("FBAN") || userAgent.Contains("FBAV"), "fb://");
+        bankId.AddCustomBrowserByUserAgent(userAgent => userAgent.Contains("Instagram"), context => new BankIdLauncherCustomBrowserConfig(new BrowserScheme("instagram://"), BrowserMightRequireUserInteractionToLaunch.Always));
+        bankId.AddCustomBrowserByUserAgent(userAgent => userAgent.Contains("FBAN") || userAgent.Contains("FBAV"), context => new BankIdLauncherCustomBrowserConfig(new BrowserScheme("fb://"), BrowserMightRequireUserInteractionToLaunch.Always));
 
         if (configuration.GetValue("ActiveLogin:BankId:UseSimulatedEnvironment", false))
         {

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/ActiveLogin/Controllers/BankIdUiAuthController.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/ActiveLogin/Controllers/BankIdUiAuthController.cs
@@ -33,6 +33,6 @@ public class BankIdUiAuthController : BankIdUiControllerBase
     [Route($"/[area]/{BankIdConstants.Routes.BankIdPathName}/{BankIdConstants.Routes.BankIdAuthControllerPath}")]
     public Task<ActionResult> Init(string returnUrl)
     {
-        return Initialize(returnUrl, BankIdConstants.Routes.BankIdAuthApiControllerName, "Init");
+        return Initialize(returnUrl, BankIdConstants.Routes.BankIdAuthApiControllerName, nameof(Init));
     }
 }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/ActiveLogin/Controllers/BankIdUiPaymentController.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/ActiveLogin/Controllers/BankIdUiPaymentController.cs
@@ -34,6 +34,6 @@ public class BankIdUiPaymentController : BankIdUiControllerBase
     [Route($"/[area]/{BankIdConstants.Routes.BankIdPathName}/{BankIdConstants.Routes.BankIdPaymentControllerPath}")]
     public Task<ActionResult> Init(string returnUrl)
     {
-        return Initialize(returnUrl, BankIdConstants.Routes.BankIdPaymentApiControllerName, "Init");
+        return Initialize(returnUrl, BankIdConstants.Routes.BankIdPaymentApiControllerName, nameof(Init));
     }
 }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/ActiveLogin/Controllers/BankIdUiSignController.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/ActiveLogin/Controllers/BankIdUiSignController.cs
@@ -34,6 +34,6 @@ public class BankIdUiSignController : BankIdUiControllerBase
     [Route($"/[area]/{BankIdConstants.Routes.BankIdPathName}/{BankIdConstants.Routes.BankIdSignControllerPath}")]
     public Task<ActionResult> Init(string returnUrl)
     {
-        return Initialize(returnUrl, BankIdConstants.Routes.BankIdSignApiControllerName, "Init");
+        return Initialize(returnUrl, BankIdConstants.Routes.BankIdSignApiControllerName, nameof(Init));
     }
 }

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/ActiveLogin/Models/BankIdUiApiInitializeResponse.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Areas/ActiveLogin/Models/BankIdUiApiInitializeResponse.cs
@@ -7,7 +7,7 @@ public class BankIdUiApiInitializeResponse
         bool deviceMightRequireUserInteractionToLaunchBankIdApp,
         bool checkStatus,
         string orderRef,
-        string? redirectUri,
+        string? launchUrl,
         string? qrStartState,
         string? qrCodeAsBase64)
     {
@@ -15,7 +15,7 @@ public class BankIdUiApiInitializeResponse
         DeviceMightRequireUserInteractionToLaunchBankIdApp = deviceMightRequireUserInteractionToLaunchBankIdApp;
         CheckStatus = checkStatus;
         OrderRef = orderRef;
-        RedirectUri = redirectUri;
+        LaunchUrl = launchUrl;
         QrStartState = qrStartState;
         QrCodeAsBase64 = qrCodeAsBase64;
     }
@@ -25,7 +25,7 @@ public class BankIdUiApiInitializeResponse
     public bool DeviceMightRequireUserInteractionToLaunchBankIdApp { get; }
     public bool CheckStatus { get; }
     public string OrderRef { get; }
-    public string? RedirectUri { get; }
+    public string? LaunchUrl { get; }
     public string? QrStartState { get; set; }
     public string? QrCodeAsBase64 { get; set; }
 
@@ -35,9 +35,9 @@ public class BankIdUiApiInitializeResponse
         return new BankIdUiApiInitializeResponse(true, showLaunchButton, false, orderRef, redirectUri, null, null);
     }
 
-    public static BankIdUiApiInitializeResponse AutoLaunchAndCheckStatus(string orderRef, string redirectUri, bool showLaunchButton)
+    public static BankIdUiApiInitializeResponse AutoLaunchAndReloadPage(string orderRef, string launchUrl, bool showLaunchButton)
     {
-        return new BankIdUiApiInitializeResponse(true, showLaunchButton, true, orderRef, redirectUri, null, null);
+        return new BankIdUiApiInitializeResponse(true, showLaunchButton, false, orderRef, launchUrl, null, null);
     }
 
     public static BankIdUiApiInitializeResponse ManualLaunch(string orderRef, string qrStartState, string qrCodeAsBase64)

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Auth/BankIdAuthHandler.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Auth/BankIdAuthHandler.cs
@@ -176,11 +176,11 @@ public class BankIdAuthHandler : RemoteAuthenticationHandler<BankIdAuthOptions>
         var detectedDevice = _bankIdSupportedDeviceDetector.Detect();
         await _bankIdEventTrigger.TriggerAsync(new BankIdAspNetChallengeSuccessEvent(detectedDevice, uiOptions.ToBankIdFlowOptions()));
 
-        var loginUrl = GetInitUiUrl(uiOptions);
+        var loginUrl = GetInitUiUrl();
         Response.Redirect(loginUrl);
     }
 
-    private string GetInitUiUrl(BankIdUiOptions uiOptions)
+    private string GetInitUiUrl()
     {
         var pathBase = Context.Request.PathBase;
         var authUrl = pathBase.Add(_authPath);

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdCommonConfiguration.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdCommonConfiguration.cs
@@ -2,11 +2,13 @@ using System.Reflection;
 
 using ActiveLogin.Authentication.BankId.AspNetCore.Cookies;
 using ActiveLogin.Authentication.BankId.AspNetCore.DataProtection;
+using ActiveLogin.Authentication.BankId.AspNetCore.Launcher;
 using ActiveLogin.Authentication.BankId.AspNetCore.StateHandling;
 using ActiveLogin.Authentication.BankId.AspNetCore.SupportedDevice;
 using ActiveLogin.Authentication.BankId.AspNetCore.UserContext;
 using ActiveLogin.Authentication.BankId.AspNetCore.UserContext.Device;
 using ActiveLogin.Authentication.BankId.Core;
+using ActiveLogin.Authentication.BankId.Core.Launcher;
 using ActiveLogin.Authentication.BankId.Core.SupportedDevice;
 using ActiveLogin.Authentication.BankId.Core.UserContext;
 
@@ -29,6 +31,9 @@ internal static class BankIdCommonConfiguration
         services.AddTransient<IBankIdSupportedDeviceDetector, BankIdSupportedDeviceDetector>();
 
         services.AddTransient<IBankIdEndUserIpResolver, BankIdRemoteIpAddressEndUserIpResolver>();
+
+        services.AddTransient<ICustomBrowserResolver, BankIdCustomBrowserResolver>();
+        services.AddTransient<IBankIdRedirectUrlResolver, BankIdRedirectUrlResolver>();
 
         services.AddHttpContextAccessor();
         services.AddTransient<IBankIdUiOptionsCookieManager, BankIdUiOptionsCookieManager>();

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdConstants.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdConstants.cs
@@ -71,15 +71,12 @@ internal static class BankIdConstants
 
         public const string BankIdAuthControllerName = "BankIdUiAuth";
         public const string BankIdAuthControllerPath = "Auth";
-        public const string BankIdAuthInitActionName = "Init";
 
         public const string BankIdSignControllerName = "BankIdUiSign";
         public const string BankIdSignControllerPath = "Sign";
-        public const string BankIdSignInitActionName = "Init";
 
         public const string BankIdPaymentControllerName = "BankIdUiPayment";
         public const string BankIdPaymentControllerPath = "Payment";
-        public const string BankIdPaymentInitActionName = "Init";
 
         public const string BankIdAuthApiControllerName = "BankIdUiAuthApi";
         public const string BankIdSignApiControllerName = "BankIdUiSignApi";

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdRedirectUrlResolver.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/BankIdRedirectUrlResolver.cs
@@ -1,0 +1,76 @@
+using ActiveLogin.Authentication.BankId.Core.Launcher;
+using ActiveLogin.Authentication.BankId.Core.SupportedDevice;
+
+using Microsoft.AspNetCore.Http;
+
+namespace ActiveLogin.Authentication.BankId.AspNetCore;
+
+public class BankIdRedirectUrlResolver(
+    IBankIdSupportedDeviceDetector deviceDetector,
+    ICustomBrowserResolver customBrowserResolver,
+    IHttpContextAccessor httpContextAccessor
+) : IBankIdRedirectUrlResolver
+{
+    public async Task<BankIdRedirectUrl> GetRedirectUrl(BankIdTransactionType type, string callbackPath)
+    {
+        var context = httpContextAccessor.HttpContext ?? throw new InvalidOperationException(BankIdConstants.ErrorMessages.CouldNotAccessHttpContext);
+        var controller = type switch
+        {
+            BankIdTransactionType.Auth => BankIdConstants.Routes.BankIdAuthControllerName,
+            BankIdTransactionType.Sign => BankIdConstants.Routes.BankIdSignControllerName,
+            BankIdTransactionType.Payment => BankIdConstants.Routes.BankIdPaymentControllerName,
+            _ => throw new InvalidOperationException("Unknown BankIdTransactionType")
+        };
+        var returnRedirectUrl = context.ResolveControllerUrl(
+            BankIdConstants.Routes.ActiveLoginAreaName,
+            controller,
+            "Init", new { returnUrl = callbackPath }
+        );
+
+        var config = await customBrowserResolver.GetConfig(new LaunchUrlRequest(returnRedirectUrl, ""));
+
+        var result = BankIdRedirectUrl.TryCreate(
+            returnRedirectUrl,
+            config,
+            deviceDetector.Detect()
+        );
+
+        return result switch
+        {
+            Result<BankIdRedirectUrl>.Success(var value) => value,
+            Result<BankIdRedirectUrl>.Failure(var error) => throw new InvalidOperationException($"Failed to create redirect URL: {error}"),
+            _ => throw new InvalidOperationException("Unexpected result when creating redirect URL")
+        };
+    }
+}
+
+public static class UrlHelperExtensions
+{
+    public static string ResolveControllerUrl(
+        this HttpContext context,
+        string area,
+        string controller,
+        string action,
+        object? routeValues = null
+    ){
+        var host = context.Request.Host.Value;
+        var url = $"https://{host}/{area}/{controller}/{action}";
+
+        if (routeValues != null)
+        {
+            var properties = routeValues.GetType().GetProperties();
+            var query = string.Join("&", properties.Select(p =>
+            {
+                var value = p.GetValue(routeValues);
+                return $"{Uri.EscapeDataString(p.Name)}={Uri.EscapeDataString(value?.ToString() ?? string.Empty)}";
+            }));
+
+            if (!string.IsNullOrEmpty(query))
+            {
+                url += "?" + query;
+            }
+        }
+
+        return url;
+    }
+}

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Client/activelogin-main.ts
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Client/activelogin-main.ts
@@ -132,7 +132,7 @@ function activeloginInit(configuration: IBankIdUiScriptConfiguration, initState:
 
                     if (data.deviceMightRequireUserInteractionToLaunchBankIdApp) {
                         var startBankIdAppButtonOnClick = (event: Event) => {
-                            window.location.href = data.redirectUri;
+                            window.location.href = data.launchUrl;
                             hide(startBankIdAppButtonElement);
                             event.target.removeEventListener("click", startBankIdAppButtonOnClick);
                         };
@@ -140,7 +140,7 @@ function activeloginInit(configuration: IBankIdUiScriptConfiguration, initState:
 
                         show(startBankIdAppButtonElement);
                     } else {
-                        window.location.href = data.redirectUri;
+                        window.location.href = data.launchUrl;
                     }
                 }
 

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/IBankIdBuilderExtensions.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/IBankIdBuilderExtensions.cs
@@ -16,6 +16,7 @@ public static class IBankIdBuilderExtensions
     /// <param name="isApplicable"></param>
     /// <param name="returnUrl"></param>
     /// <returns></returns>
+    [Obsolete("Use AddCustomBrowserByUserAgent that returns a BankIdLauncherCustomBrowserConfig instead.")]
     public static IBankIdBuilder AddCustomBrowserByUserAgent(this IBankIdBuilder builder, Func<string, bool> isApplicable, string returnUrl)
     {
         return AddCustomBrowserByUserAgent(builder, isApplicable, context => returnUrl);
@@ -29,6 +30,7 @@ public static class IBankIdBuilderExtensions
     /// <param name="isApplicable"></param>
     /// <param name="getReturnUrl"></param>
     /// <returns></returns>
+    [Obsolete("Use AddCustomBrowserByUserAgent that returns a BankIdLauncherCustomBrowserConfig instead.")]
     public static IBankIdBuilder AddCustomBrowserByUserAgent(this IBankIdBuilder builder, Func<string, bool> isApplicable, Func<BankIdLauncherCustomBrowserContext, string> getReturnUrl)
     {
         BankIdLauncherCustomBrowserConfig GetResult(BankIdLauncherCustomBrowserContext context) => new(getReturnUrl(context), BrowserReloadBehaviourOnReturnFromBankIdApp.Never);

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Launcher/BankIdCustomBrowserResolver.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Launcher/BankIdCustomBrowserResolver.cs
@@ -1,0 +1,24 @@
+using ActiveLogin.Authentication.BankId.Core.Launcher;
+using ActiveLogin.Authentication.BankId.Core.SupportedDevice;
+
+namespace ActiveLogin.Authentication.BankId.AspNetCore.Launcher;
+
+public class BankIdCustomBrowserResolver(
+    IBankIdSupportedDeviceDetector deviceDetector,
+    IEnumerable<IBankIdLauncherCustomBrowser> customBrowsers
+) : ICustomBrowserResolver
+{
+    public async Task<BankIdLauncherCustomBrowserConfig?> GetConfig(LaunchUrlRequest launchUrlRequest)
+    {
+        var device = deviceDetector.Detect();
+        var context = new BankIdLauncherCustomBrowserContext(device, launchUrlRequest);
+        foreach (var browser in customBrowsers)
+        {
+            if (await browser.IsApplicable(context))
+            {
+                return await browser.GetCustomAppCallbackResult(context);
+            }
+        }
+        return null;
+    }
+}

--- a/src/ActiveLogin.Authentication.BankId.Core/Launcher/BankIdDevelopmentLauncher.cs
+++ b/src/ActiveLogin.Authentication.BankId.Core/Launcher/BankIdDevelopmentLauncher.cs
@@ -3,11 +3,10 @@ namespace ActiveLogin.Authentication.BankId.Core.Launcher;
 internal class BankIdDevelopmentLauncher : IBankIdLauncher
 {
     private const string DevelopmentLaunchUrl = "#";
-    private const string DevelopmentReturnUrl = "";
 
     public Task<BankIdLaunchInfo> GetLaunchInfoAsync(LaunchUrlRequest request)
     {
         // Always stay on same page, without reloading, in simulated mode
-        return Task.FromResult(new BankIdLaunchInfo(DevelopmentLaunchUrl, false, false, DevelopmentReturnUrl));
+        return Task.FromResult(new BankIdLaunchInfo(DevelopmentLaunchUrl, false, false));
     }
 }

--- a/src/ActiveLogin.Authentication.BankId.Core/Launcher/BankIdLaunchInfo.cs
+++ b/src/ActiveLogin.Authentication.BankId.Core/Launcher/BankIdLaunchInfo.cs
@@ -1,90 +1,38 @@
-using ActiveLogin.Authentication.BankId.Api.Models;
-
 namespace ActiveLogin.Authentication.BankId.Core.Launcher;
 
-public class BankIdLaunchInfo
+/// <summary>
+/// Information about the launch of the BankID app.
+/// </summary>
+/// <param name="launchUrl">The URL used to launch the BankID app.</param>
+/// <param name="deviceMightRequireUserInteractionToLaunchBankIdApp">
+/// True if the device/browser might require user interaction, such as a button click, to launch the BankID app.
+/// </param>
+public class BankIdLaunchInfo(
+    string launchUrl,
+    bool deviceMightRequireUserInteractionToLaunchBankIdApp)
 {
-    /// <summary>
-    /// Creates a new <see cref="BankIdLaunchInfo"/> instance.
-    /// </summary>
-    /// <param name="launchUrl">The URL used to launch the BankID app.</param>
-    /// <param name="deviceMightRequireUserInteractionToLaunchBankIdApp">
-    /// True if the device/browser might require user interaction, such as a button click, to launch the BankID app.
-    /// </param>
-    /// <param name="deviceWillReloadPageOnReturnFromBankIdApp">
-    /// True if the device/browser will reload the page when returning from the BankID app.
-    /// </param>
-    /// <param name="returnUrl">
-    /// The return URL to send to BankID as part of the backend call when creating the order (auth, sign, or payment).
-    /// This URL will be called when the order completes. It is recommended to provide the return URL
-    /// via the backend call rather than including it in the autolaunch URL.
-    /// </param>
-    public BankIdLaunchInfo(
-        string launchUrl,
-        bool deviceMightRequireUserInteractionToLaunchBankIdApp,
-        bool deviceWillReloadPageOnReturnFromBankIdApp,
-        string returnUrl)
-    {
-        LaunchUrl = launchUrl;
-        DeviceMightRequireUserInteractionToLaunchBankIdApp = deviceMightRequireUserInteractionToLaunchBankIdApp;
-        DeviceWillReloadPageOnReturnFromBankIdApp = deviceWillReloadPageOnReturnFromBankIdApp;
-        ReturnUrl = returnUrl;
-    }
 
-    /// <summary>
-    /// DEPRECATED: Use the constructor that requires returnUrl.
-    /// This overload will be removed in a future release.
-    /// </summary>
-    /// <param name="launchUrl">The URL used to launch the BankID app.</param>
-    /// <param name="deviceMightRequireUserInteractionToLaunchBankIdApp">
-    /// True if the device/browser might require user interaction, such as a button click, to launch the BankID app.
-    /// </param>
-    /// <param name="deviceWillReloadPageOnReturnFromBankIdApp">
-    /// True if the device/browser will reload the page when returning from the BankID app.
-    /// </param>
-    [Obsolete("Use the constructor that requires 'returnUrl'. This overload will be removed in a future release.")]
-    public BankIdLaunchInfo(
-        string launchUrl,
-        bool deviceMightRequireUserInteractionToLaunchBankIdApp,
-        bool deviceWillReloadPageOnReturnFromBankIdApp)
+    public BankIdLaunchInfo(string launchUrl, bool deviceMightRequireUserInteractionToLaunchBankIdApp, bool deviceWillReloadPageOnReturnFromBankIdApp)
+        : this(launchUrl, deviceMightRequireUserInteractionToLaunchBankIdApp)
     {
-        LaunchUrl = launchUrl;
-        DeviceMightRequireUserInteractionToLaunchBankIdApp = deviceMightRequireUserInteractionToLaunchBankIdApp;
-        DeviceWillReloadPageOnReturnFromBankIdApp = deviceWillReloadPageOnReturnFromBankIdApp;
-        ReturnUrl = null;
+        // For backward compatibility
     }
 
     /// <summary>
     /// Returns the url used to launch the BankID app.
     /// </summary>
-    public string LaunchUrl { get; }
+    public string LaunchUrl { get; } = launchUrl;
 
     /// <summary>
     /// If the device/browser might require user interaction, such as button click, to launch a third party app.
     /// </summary>
     /// <returns></returns>
-    public bool DeviceMightRequireUserInteractionToLaunchBankIdApp { get; }
+    public bool DeviceMightRequireUserInteractionToLaunchBankIdApp { get; } = deviceMightRequireUserInteractionToLaunchBankIdApp;
 
     /// <summary>
     /// If the device/browser will reload the page on return from the BankID app.
     /// </summary>
     /// <returns></returns>
+    [Obsolete("This will be determined by the returnUrl sent to BankId")]
     public bool DeviceWillReloadPageOnReturnFromBankIdApp { get; }
-
-    /// <summary>
-    /// Return URL used when the order is started on the same device
-    /// where the user’s BankID is installed (i.e using the <see cref="LaunchUrl"/>).
-    /// When the order completes, the BankID app will redirect to this URL.
-    ///
-    /// If both a return URL is specified here and one was provided as part of the <see cref="LaunchUrl"/>,
-    /// using the redirect parameter. BankID will ignore the one in the redirect paramter and use this value instead.
-    /// 
-    /// If the user has a version of the BankID app that does not support getting the returnUrl from the server,
-    /// the order will be cancelled and the user will be asked to update their app.
-    /// 
-    /// The return URL you provide should include a nonce to the session.
-    /// When the user returns to your app or web page, your service should verify that
-    /// the device receiving the returnUrl is the same device that started the order.
-    /// </summary>
-    public string? ReturnUrl { get; }
 }

--- a/src/ActiveLogin.Authentication.BankId.Core/Launcher/BankIdLauncher.cs
+++ b/src/ActiveLogin.Authentication.BankId.Core/Launcher/BankIdLauncher.cs
@@ -5,43 +5,28 @@ using ActiveLogin.Authentication.BankId.Core.SupportedDevice;
 
 namespace ActiveLogin.Authentication.BankId.Core.Launcher;
 
-internal class BankIdLauncher : IBankIdLauncher
+internal class BankIdLauncher(
+    IBankIdSupportedDeviceDetector bankIdSupportedDeviceDetector,
+    ICustomBrowserResolver customBrowserResolver
+) : IBankIdLauncher
 {
     private const string BankIdSchemePrefix = "bankid:///";
     private const string BankIdAppLinkPrefix = "https://app.bankid.com/";
 
     private const string BankIdAutoStartTokenQueryStringParamName = "autostarttoken";
     private const string BankIdRpRefQueryStringParamName = "rpref";
-    private const string BankIdRedirectQueryStringParamName = "redirect";
 
-    private const string NullRedirectUrl = "null";
-
-    private const string IosChromeScheme = "googlechromes://";
-    private const string IosFirefoxScheme = "firefox://";
-
-    private readonly IBankIdSupportedDeviceDetector _bankIdSupportedDeviceDetector;
-    private readonly List<IBankIdLauncherCustomBrowser> _customBrowsers;
-
-    public BankIdLauncher(IBankIdSupportedDeviceDetector bankIdSupportedDeviceDetector, IEnumerable<IBankIdLauncherCustomBrowser> customBrowsers)
-    {
-        _bankIdSupportedDeviceDetector = bankIdSupportedDeviceDetector;
-        _customBrowsers = customBrowsers.ToList();
-    }
+    private readonly IBankIdSupportedDeviceDetector _bankIdSupportedDeviceDetector = bankIdSupportedDeviceDetector;
 
     public async Task<BankIdLaunchInfo> GetLaunchInfoAsync(LaunchUrlRequest request)
     {
         var detectedDevice = _bankIdSupportedDeviceDetector.Detect();
-
-        var customBrowserContext = new BankIdLauncherCustomBrowserContext(detectedDevice, request);
-        var customBrowser = await GetRelevantCustomAppCallbackAsync(customBrowserContext, _customBrowsers);
-        var customBrowserConfig = customBrowser != null ? (await customBrowser.GetCustomAppCallbackResult(customBrowserContext)) : null;
+        var customBrowserConfig = await customBrowserResolver.GetConfig(request);
 
         var deviceMightRequireUserInteractionToLaunch = GetDeviceMightRequireUserInteractionToLaunchBankIdApp(detectedDevice, customBrowserConfig);
-        var deviceWillReloadPageOnReturn = GetDeviceWillReloadPageOnReturnFromBankIdApp(detectedDevice, customBrowserConfig);
-        var launchUrl = GetLaunchUrl(detectedDevice, request, customBrowserConfig);
-        var returnUrl = GetRedirectUrl(detectedDevice, request, customBrowserConfig);
+        var launchUrl = GetLaunchUrl(detectedDevice, request);
 
-        return new BankIdLaunchInfo(launchUrl, deviceMightRequireUserInteractionToLaunch, deviceWillReloadPageOnReturn, returnUrl);
+        return new BankIdLaunchInfo(launchUrl, deviceMightRequireUserInteractionToLaunch);
     }
 
     private bool GetDeviceMightRequireUserInteractionToLaunchBankIdApp(BankIdSupportedDevice detectedDevice, BankIdLauncherCustomBrowserConfig? customBrowserConfig)
@@ -58,39 +43,24 @@ internal class BankIdLauncher : IBankIdLauncher
             //
             // - Chrome, Edge, Samsung Internet Browser and Brave is confirmed to require User Interaction
             // - Firefox and Opera is confirmed to work without User Interaction
-            _ => detectedDevice.DeviceOs == BankIdSupportedDeviceOs.Android
-                 && detectedDevice.DeviceBrowser != BankIdSupportedDeviceBrowser.Firefox
-                 && detectedDevice.DeviceBrowser != BankIdSupportedDeviceBrowser.Opera
-        };
-    }
-
-    private bool GetDeviceWillReloadPageOnReturnFromBankIdApp(BankIdSupportedDevice detectedDevice, BankIdLauncherCustomBrowserConfig? customBrowserConfig)
-    {
-        var reloadBehaviour = customBrowserConfig?.BrowserReloadBehaviourOnReturnFromBankIdApp ?? BrowserReloadBehaviourOnReturnFromBankIdApp.Default;
-
-        return reloadBehaviour switch
-        {
-            BrowserReloadBehaviourOnReturnFromBankIdApp.Always => true,
-            BrowserReloadBehaviourOnReturnFromBankIdApp.Never => false,
-
-            // By default, Safari on iOS will refresh the page/tab when returned from the BankID app
-            _ => detectedDevice is
-            {
-                DeviceOs: BankIdSupportedDeviceOs.Ios,
-                DeviceBrowser: BankIdSupportedDeviceBrowser.Safari
+            //
+            // On iOS, browsers do not have this restriction
+            _ => detectedDevice is {
+                DeviceOs: BankIdSupportedDeviceOs.Android,
+                DeviceBrowser: not (BankIdSupportedDeviceBrowser.Firefox or BankIdSupportedDeviceBrowser.Opera)
             }
         };
     }
 
-    private string GetLaunchUrl(BankIdSupportedDevice device, LaunchUrlRequest request, BankIdLauncherCustomBrowserConfig? customBrowserConfig)
+    private static string GetLaunchUrl(BankIdSupportedDevice device, LaunchUrlRequest request)
     {
         var prefix = GetPrefixPart(device);
-        var queryString = GetQueryStringPart(device, request, customBrowserConfig);
+        var queryString = GetQueryStringPart(request);
 
         return $"{prefix}{queryString}";
     }
 
-    private string GetPrefixPart(BankIdSupportedDevice device)
+    private static string GetPrefixPart(BankIdSupportedDevice device)
     {
         return CanUseAppLink(device)
             ? BankIdAppLinkPrefix
@@ -115,7 +85,7 @@ internal class BankIdLauncher : IBankIdLauncher
         };
     }
 
-    private string GetQueryStringPart(BankIdSupportedDevice device, LaunchUrlRequest request, BankIdLauncherCustomBrowserConfig? customBrowserConfig)
+    private static string GetQueryStringPart(LaunchUrlRequest request)
     {
         var queryStringParams = new Dictionary<string, string>();
 
@@ -129,65 +99,7 @@ internal class BankIdLauncher : IBankIdLauncher
             queryStringParams.Add(BankIdRpRefQueryStringParamName, Base64Encode(request.RelyingPartyReference));
         }
 
-        var redirectUrl = GetRedirectUrl(device, request, customBrowserConfig);
-
-        // DEPRECATED: Setting the return URL here is no longer the recommended approach.
-        // The return URL should now be specified in the backend call to BankID when
-        // creating the order (auth, sign, or payment).
-        // This parameter is kept only for backward compatibility. If both values are set,
-        // BankID will use the one provided in the backend call.
-        queryStringParams.Add(BankIdRedirectQueryStringParamName, redirectUrl);
-
         return QueryStringGenerator.ToQueryString(queryStringParams);
-    }
-
-    private static string GetRedirectUrl(BankIdSupportedDevice device, LaunchUrlRequest request, BankIdLauncherCustomBrowserConfig? customBrowserConfig)
-    {
-        // Allow for easy override of callback url
-        if (customBrowserConfig != null && customBrowserConfig.ReturnUrl != null)
-        {
-            return customBrowserConfig.ReturnUrl;
-        }
-
-        // Only use redirect url for iOS as recommended in BankID Guidelines 3.1.2
-        return device.DeviceOs == BankIdSupportedDeviceOs.Ios
-            ? GetIOsBrowserSpecificRedirectUrl(device, request.RedirectUrl, customBrowserConfig)
-            : NullRedirectUrl;
-    }
-
-    private static string GetIOsBrowserSpecificRedirectUrl(BankIdSupportedDevice device, string redirectUrl, BankIdLauncherCustomBrowserConfig? customBrowserConfig)
-    {
-        // If it is a third party browser, don't specify the return URL, just the browser scheme.
-        // This will launch the browser with the last page used (the Active Login status page).
-        // If a URL is specified these browsers will open that URL in a new tab and we will lose context.
-
-        return device.DeviceBrowser switch
-        {
-            // Safari can only be launched by providing redirect url (https://...)
-            BankIdSupportedDeviceBrowser.Safari => redirectUrl,
-
-            // Normally you would supply the URL, but we just want to launch the app again
-            BankIdSupportedDeviceBrowser.Chrome => IosChromeScheme,
-            BankIdSupportedDeviceBrowser.Firefox => IosFirefoxScheme,
-
-            BankIdSupportedDeviceBrowser.Edge => NullRedirectUrl,
-            BankIdSupportedDeviceBrowser.Opera => NullRedirectUrl,
-
-            _ => NullRedirectUrl
-        };
-    }
-
-    private static async Task<IBankIdLauncherCustomBrowser?> GetRelevantCustomAppCallbackAsync(BankIdLauncherCustomBrowserContext customBrowserContext, List<IBankIdLauncherCustomBrowser> customAppCallbacks)
-    {
-        foreach (var callback in customAppCallbacks)
-        {
-            if (await callback.IsApplicable(customBrowserContext))
-            {
-                return callback;
-            }
-        }
-
-        return null;
     }
 
     private static string Base64Encode(string value)

--- a/src/ActiveLogin.Authentication.BankId.Core/Launcher/BankIdLauncherCustomBrowserByContext.cs
+++ b/src/ActiveLogin.Authentication.BankId.Core/Launcher/BankIdLauncherCustomBrowserByContext.cs
@@ -1,25 +1,17 @@
 namespace ActiveLogin.Authentication.BankId.Core.Launcher;
 
-public class BankIdLauncherCustomBrowserByContext : IBankIdLauncherCustomBrowser
+public class BankIdLauncherCustomBrowserByContext(
+    Func<BankIdLauncherCustomBrowserContext, bool> isApplicable,
+    Func<BankIdLauncherCustomBrowserContext, BankIdLauncherCustomBrowserConfig> getResult
+) : IBankIdLauncherCustomBrowser
 {
-    private readonly Func<BankIdLauncherCustomBrowserContext, bool> _isApplicable;
-    private readonly Func<BankIdLauncherCustomBrowserContext, BankIdLauncherCustomBrowserConfig> _getResult;
-
-    public BankIdLauncherCustomBrowserByContext(Func<BankIdLauncherCustomBrowserContext, bool> isApplicable, Func<BankIdLauncherCustomBrowserContext, BankIdLauncherCustomBrowserConfig> getResult)
-    {
-        _isApplicable = isApplicable;
-        _getResult = getResult;
-    }
-
     public Task<bool> IsApplicable(BankIdLauncherCustomBrowserContext context)
     {
-        var isApplicable = _isApplicable(context);
-        return Task.FromResult(isApplicable);
+        return Task.FromResult(isApplicable(context));
     }
 
     public Task<BankIdLauncherCustomBrowserConfig> GetCustomAppCallbackResult(BankIdLauncherCustomBrowserContext context)
     {
-        var result = _getResult(context);
-        return Task.FromResult(result);
+        return Task.FromResult(getResult(context));
     }
 }

--- a/src/ActiveLogin.Authentication.BankId.Core/Launcher/BankIdLauncherCustomBrowserConfig.cs
+++ b/src/ActiveLogin.Authentication.BankId.Core/Launcher/BankIdLauncherCustomBrowserConfig.cs
@@ -1,8 +1,31 @@
 namespace ActiveLogin.Authentication.BankId.Core.Launcher;
 
+public record BrowserScheme(string scheme)
+{
+    // we need to trim any trailing :// to make it easier to use
+    private readonly string _value = scheme.TrimEnd(':', '/');
+
+    public override string ToString() => _value;
+    public static implicit operator string(BrowserScheme browserScheme) => browserScheme._value;
+}
+
 public class BankIdLauncherCustomBrowserConfig
 {
-    public BankIdLauncherCustomBrowserConfig(string? returnUrl, BrowserReloadBehaviourOnReturnFromBankIdApp browserReloadBehaviourOnReturnFromBankIdApp = BrowserReloadBehaviourOnReturnFromBankIdApp.Default, BrowserMightRequireUserInteractionToLaunch browserMightRequireUserInteractionToLaunch = BrowserMightRequireUserInteractionToLaunch.Default)
+    public BankIdLauncherCustomBrowserConfig(
+        BrowserScheme browserScheme,
+        BrowserMightRequireUserInteractionToLaunch browserMightRequireUserInteractionToLaunch
+    )
+    {
+        BrowserScheme = browserScheme;
+        BrowserMightRequireUserInteractionToLaunch = browserMightRequireUserInteractionToLaunch;
+    }
+
+    [Obsolete("Specifying ReturnUrl is deprecated, use BrowserScheme instead.")]
+    public BankIdLauncherCustomBrowserConfig(
+        string? returnUrl,
+        BrowserReloadBehaviourOnReturnFromBankIdApp browserReloadBehaviourOnReturnFromBankIdApp = BrowserReloadBehaviourOnReturnFromBankIdApp.Default,
+        BrowserMightRequireUserInteractionToLaunch browserMightRequireUserInteractionToLaunch = BrowserMightRequireUserInteractionToLaunch.Default
+    )
     {
         ReturnUrl = returnUrl;
         BrowserReloadBehaviourOnReturnFromBankIdApp = browserReloadBehaviourOnReturnFromBankIdApp;
@@ -15,11 +38,14 @@ public class BankIdLauncherCustomBrowserConfig
     /// Set to empty string to not launch any URL, and instead the BanKID app will ask the user to open the last app.
     /// This will only be applied to iOS as Android automatically launches the previous app.
     /// </summary>
+    [Obsolete("Deprecated in favor of only specifying BrowserScheme")]
     public string? ReturnUrl { get; set; }
+    public BrowserScheme? BrowserScheme { get; set; }
 
     /// <summary>
     /// The reload behaviour of the browser when returning from the BankID app.
     /// </summary>
+    [Obsolete("This setting is deprecated and will be removed in future versions.")]
     public BrowserReloadBehaviourOnReturnFromBankIdApp BrowserReloadBehaviourOnReturnFromBankIdApp { get; set; }
 
     /// <summary>

--- a/src/ActiveLogin.Authentication.BankId.Core/Launcher/BankIdRedirectUrl.cs
+++ b/src/ActiveLogin.Authentication.BankId.Core/Launcher/BankIdRedirectUrl.cs
@@ -1,0 +1,156 @@
+using System.Diagnostics.CodeAnalysis;
+
+using ActiveLogin.Authentication.BankId.Core.SupportedDevice;
+
+namespace ActiveLogin.Authentication.BankId.Core.Launcher;
+
+
+/*
+Android with Edge: bankid://
+*/
+
+/// <summary>
+/// The redirect URL: <br/>
+/// * Must be UTF-8 and URL encoded. <br/>
+/// * Should take the user back to the same webpage. <br/>
+/// * May include parameters to be passed to the browser. <br/>
+/// * Can be set to null.
+/// </summary>
+public record BankIdRedirectUrl
+{
+    private const string IosChromeScheme = "chromebrowser";
+    private const string IosFirefoxScheme = "firefox";
+
+    public required string Url { get; init; }
+
+    private BankIdRedirectUrl(){}
+
+    public static Result<BankIdRedirectUrl> TryCreate(
+        string redirectUrl,
+        BankIdLauncherCustomBrowserConfig? config,
+        BankIdSupportedDevice device
+    )
+    {
+        if (string.IsNullOrWhiteSpace(redirectUrl))
+        {
+            return "Invalid URL";
+        }
+
+        // only https allowed
+        if (!redirectUrl.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+        {
+            return "Only https scheme is allowed in redirect URL";
+        }
+
+        // get custom browser scheme if any, otherwise get scheme based on device
+        var browserScheme = config?.BrowserScheme is not null
+            ? config.BrowserScheme
+            : GetScheme(device);
+
+        redirectUrl = !string.IsNullOrWhiteSpace(browserScheme)
+            ? redirectUrl.Replace("https", browserScheme, StringComparison.OrdinalIgnoreCase)
+            : redirectUrl;
+
+        var url = Uri.EscapeDataString(redirectUrl);
+
+        if (512 < url.Length)
+        {
+            return "URL must be at most 512 characters long";
+        }
+
+        return new BankIdRedirectUrl
+        {
+            Url = url
+        };
+    }
+
+    private static string? GetScheme(BankIdSupportedDevice device)
+    {
+        // This will launch the browser with the last page used (the Active Login status page).
+        // If a URL is specified these browsers will open that URL in a new tab and we will lose context.
+        return device.DeviceOs switch
+        {
+            BankIdSupportedDeviceOs.Ios => device.DeviceBrowser switch
+            {
+                BankIdSupportedDeviceBrowser.Chrome => IosChromeScheme, // Normally you would supply the URL, but we just want to launch the app again
+                BankIdSupportedDeviceBrowser.Firefox => IosFirefoxScheme, // Normally you would supply the URL, but we just want to launch the app again
+                _ => null
+            },
+            _ => null
+        };
+    }
+
+    public override string ToString() => Url;
+
+    [return: NotNullIfNotNull(nameof(bankIdRedirectUrl))]
+    public static implicit operator string?(BankIdRedirectUrl? bankIdRedirectUrl) => bankIdRedirectUrl?.Url;
+};
+
+/*
+# Return URL
+When the BankID client is used on the same device as the user visits your service on,
+the user should be sent back to your service once they've completed their action in the BankID client.
+From version 6 of our RP-API, it's possible and strongly recommended to send the return URL via server,
+meaning that you can protect the user and ensure that any sessions started from your service will send them back to your service.
+This can mitigate some session fixation cases.
+
+Note that usage of return URL as part of autostart URL is deprecated. Instead, the return URL
+should be included in the RP-API call when starting an order.
+
+## How it works
+
+### For Web
+1. The user visits your website at https://www.example.com
+2. The user chooses to log in. https://www.example.com/login
+3. Your website makes a call to our RP-API which includes, among other things, the return URL: https://www.example.com/login#nonce=[session nonce]
+4. The RP-API returns the autostart token.
+5. Your website starts the BankID client using the autostart URL. Example: https://app.bankid.com/?autostarttoken=[autostarttoken from step 4]
+6. The user completes the identification in the BankID app.
+7. The BankID app invokes the return URL, previously sent to the RP-API in step 3.
+8. Your website verifies that the nonce matches the session nonce.
+
+### For App
+1. The user starts your app.
+2. The user chooses to log in.
+3. Your app makes a server side call to our RP-API, which includes, among other things, the app specific return URL: https://app.example.com/login#nonce=[session nonce] or myapp://login#nonce=[session nonce].
+4. The RP-API returns the autostart token.
+5. Your app starts the BankID client using the autostart URL. Example: https://app.bankid.com/?autostarttoken=[autostarttoken from step 4]
+6. The user completes the identification in the BankID app.
+7. The BankID app invokes the return URL, previously sent to the RP-API in step 3.
+8. Your app verifies that the nonce matches the session nonce.
+
+Please note: If the user has an older desktop version of the BankID client that doesn't support getting the
+return URL from the server, the order will be cancelled and the user will be asked to update their app.
+
+## Pitfalls in web flows
+In cases where the user visits your service in a web browser you can face some challenges when it comes to returning
+them to the right broswser or app. This is due to device settings and/or differences in browser behaviour and is
+out of our control. However, there are some things you can do to enhance the probability that the user is
+returned to the right browser and/or tab.
+
+## Returning the user to correct browser
+The return URL will be opened in the default browser, even if the user started the session in a different browser.
+
+If the used brower has a documented URL scheme this should be used in the return URL instead of 'https'.
+
+Example: https://www.example.com/ for Google Chrome would be: chromebrowser://www.example.com/.
+
+Please note: For browser without a documented URL scheme, the user will be sent to the default browser.
+
+## Returning the user to correct tab
+For a good user experience, returning the user to the same tab is preferred.
+However, it can be a challenge to do this from an app, such as BankID security app.
+
+The highest probability to return the user to the tab where they started BankID from,
+is to use the exact URL of the target tab as the return URL.
+However, to bind the new request to the old browser session,
+the return URL should include a nonce that server side will match to the old browser session.
+The best way to accomplish this is to place the nonce in the URL fragment.
+Please note that the nonce should not contain sensitive session information such as the session cookie.
+
+Example: https://www.example.com/login#nonce=[session nonce]
+
+## Returning the user to correct browser and tab
+When combining the methods above, some browsers may deliver unexpected results. This is because different browser behave differently when given the same input. It's important that you test different scenarios for your service.
+
+*/

--- a/src/ActiveLogin.Authentication.BankId.Core/Launcher/IBankIdRedirectUrlResolver.cs
+++ b/src/ActiveLogin.Authentication.BankId.Core/Launcher/IBankIdRedirectUrlResolver.cs
@@ -1,0 +1,13 @@
+namespace ActiveLogin.Authentication.BankId.Core.Launcher;
+
+public enum BankIdTransactionType
+{
+    Auth,
+    Sign,
+    Payment
+}
+
+public interface IBankIdRedirectUrlResolver
+{
+    Task<BankIdRedirectUrl> GetRedirectUrl(BankIdTransactionType type, string callbackPath);
+}

--- a/src/ActiveLogin.Authentication.BankId.Core/Launcher/ICustomBrowserResolver.cs
+++ b/src/ActiveLogin.Authentication.BankId.Core/Launcher/ICustomBrowserResolver.cs
@@ -1,0 +1,6 @@
+namespace ActiveLogin.Authentication.BankId.Core.Launcher;
+
+public interface ICustomBrowserResolver
+{
+    Task<BankIdLauncherCustomBrowserConfig?> GetConfig(LaunchUrlRequest launchUrlRequest);
+}

--- a/src/ActiveLogin.Authentication.BankId.Core/Option.cs
+++ b/src/ActiveLogin.Authentication.BankId.Core/Option.cs
@@ -1,0 +1,36 @@
+namespace System;
+
+public abstract record Option<T>
+{
+    public sealed record Some(T Value) : Option<T>;
+    public sealed record None() : Option<T>;
+
+    public bool IsSome => this is Some;
+    public bool IsNone => this is None;
+
+    public T UnwrapOr(T defaultValue) => this is Some(var value) ? value : defaultValue;
+
+    public void Match(Action<T> onSome, Action onNone)
+    {
+        if (this is Some(var value))
+        {
+            onSome(value);
+        }
+        else if (this is None)
+        {
+            onNone();
+        }
+    }
+
+    public Option<T> Map(Func<T, T> f)
+    {
+        return this switch
+        {
+            Some(var value) => new Some(f(value)),
+            None => new None(),
+            _ => throw new InvalidOperationException("Unrecognized option type")
+        };
+    }
+
+    public static implicit operator Option<T>(T value) => new Some(value);
+}

--- a/src/ActiveLogin.Authentication.BankId.Core/Result.cs
+++ b/src/ActiveLogin.Authentication.BankId.Core/Result.cs
@@ -1,0 +1,61 @@
+namespace System;
+
+public abstract record Result<T>
+{
+    public static Result<T> From(T value, string? errorMessage)
+    {
+        return errorMessage is null
+            ? new Success(value)
+            : new Failure(errorMessage);
+    }
+
+    public sealed record Success(T Value) : Result<T>;
+    public sealed record Failure(string ErrorMessage) : Result<T>;
+
+    public bool IsSuccess => this is Success;
+    public bool IsFailure => this is Failure;
+
+    /// <summary>
+    /// Maps the result value if success, otherwise propagates the failure.
+    /// </summary>
+    /// <typeparam name="TOut"></typeparam>
+    /// <param name="f"></param>
+    /// <returns></returns>
+    /// <exception cref="InvalidOperationException"></exception>
+    public Result<TOut> Map<TOut>(Func<T, TOut> f)
+    {
+        return this switch
+        {
+            Success(var value) => new Result<TOut>.Success(f(value)),
+            Failure(var errorMessage) => new Result<TOut>.Failure(errorMessage),
+            _ => throw new InvalidOperationException("Unrecognized result type")
+        };
+    }
+
+    /// <summary>
+    /// Pattern match on the result.
+    /// </summary>
+    /// <param name="onSuccess"></param>
+    /// <param name="onFailure"></param>
+    public void Match(Action<T> onSuccess, Action<string> onFailure)
+    {
+        if (this is Success(var value))
+        {
+            onSuccess(value);
+        }
+        else if (this is Failure(var errorMessage))
+        {
+            onFailure(errorMessage);
+        }
+    }
+
+    /// <summary>
+    /// Unwraps the result value if success, otherwise returns the provided default value.
+    /// </summary>
+    /// <param name="defaultValue"></param>
+    /// <returns></returns>
+    public T UnwrapOr(T defaultValue) => this is Success(var value) ? value : defaultValue;
+
+    public static implicit operator Result<T>(T value) => new Success(value);
+    public static implicit operator Result<T>(string errorMessage) => new Failure(errorMessage);
+}

--- a/src/ActiveLogin.Authentication.BankId.Core/ServiceCollectionBankIdExtensions.cs
+++ b/src/ActiveLogin.Authentication.BankId.Core/ServiceCollectionBankIdExtensions.cs
@@ -50,7 +50,7 @@ public static class ServiceCollectionBankIdExtensions
         UseUserAgentFromContext(bankIdBuilder);
 
         bankId(bankIdBuilder);
-        
+
         return services;
     }
 
@@ -75,7 +75,7 @@ public static class ServiceCollectionBankIdExtensions
         builder.AddEventListener<BankIdResultStoreEventListener>();
 
         builder.AddResultStore<BankIdResultTraceLoggerStore>();
-        
+
     }
 
     private static void UseUserAgentFromContext(this IBankIdBuilder builder)
@@ -92,7 +92,7 @@ public static class ServiceCollectionBankIdExtensions
         httpClient.DefaultRequestHeaders.UserAgent.Clear();
         httpClient.DefaultRequestHeaders.UserAgent.Add(productInfoHeaderValue);
     }
-    
+
     private static (string name, string version) GetActiveLoginInfo()
     {
         var productName = BankIdConstants.ProductName;

--- a/test/ActiveLogin.Authentication.BankId.AspNetCore.Test/BankId_UiPayment_Tests.cs
+++ b/test/ActiveLogin.Authentication.BankId.AspNetCore.Test/BankId_UiPayment_Tests.cs
@@ -339,55 +339,6 @@ public class BankId_UiPayment_Tests : BankId_Ui_Tests_Base
     }
 
     [Fact]
-    public async Task AutoLaunch_Sets_Correct_RedirectUri()
-    {
-        // Arrange mocks
-        var autoLaunchOptions = new BankIdUiOptions(new List<BankIdCertificatePolicy>(), true, false, false, false, string.Empty, DefaultStateCookieName, CardReader.class1);
-
-        _bankIdUiOptionsCookieManager
-            .Setup(protector => protector.Retrieve())
-            .Returns(autoLaunchOptions);
-
-        using var server = CreateServer(
-            o =>
-            {
-                o.UseSimulatedEnvironment();
-                o.Services.AddTransient<IBankIdLauncher, TestBankIdLauncher>();
-            },
-            o =>
-            {
-                o.AddSameDevice();
-            },
-            DefaultAppConfiguration(async context =>
-            {
-                await InitiatePayment(context);
-            }),
-            services =>
-            {
-                services.AddTransient(s => _bankIdUiOptionsCookieManager.Object);
-                services.AddTransient(s => _bankIdUiStateProtector.Object);
-            });
-
-        // Arrange acting request
-        var testReturnUrl = "/TestReturnUrl";
-        var initializeRequestBody = new { returnUrl = testReturnUrl};
-
-        // Act
-        var initializeTransaction = await GetInitializeResponse(server, initializeRequestBody);
-
-        // Assert
-        Assert.Equal(HttpStatusCode.OK, initializeTransaction.StatusCode);
-
-        var responseContent = await initializeTransaction.Content.ReadAsStringAsync();
-        var responseObject = JsonConvert.DeserializeAnonymousType(responseContent, new { RedirectUri = "", OrderRef = "", IsAutoLaunch = false });
-        Assert.True(responseObject.IsAutoLaunch);
-
-        var encodedReturnParam = UrlEncoder.Default.Encode(testReturnUrl);
-        var expectedUrl = $"http://localhost/ActiveLogin/BankId/Payment?returnUrl={encodedReturnParam}";
-        Assert.Equal(expectedUrl, responseObject.RedirectUri);
-    }
-
-    [Fact]
     public async Task Api_Always_Returns_CamelCase_Json_For_Http200Ok()
     {
         // Arrange mocks
@@ -438,7 +389,7 @@ public class BankId_UiPayment_Tests : BankId_Ui_Tests_Base
         Assert.Equal(HttpStatusCode.OK, initializeTransaction.StatusCode);
 
         var responseContent = await initializeTransaction.Content.ReadAsStringAsync();
-        Assert.Contains("redirectUri", responseContent);
+        Assert.Contains("launchUrl", responseContent);
         Assert.Contains("orderRef", responseContent);
         Assert.Contains("isAutoLaunch", responseContent);
     }
@@ -565,7 +516,7 @@ public class BankId_UiPayment_Tests : BankId_Ui_Tests_Base
 
         return new TestServer(webHostBuilder);
     }
-    
+
     private static Action<IApplicationBuilder> DefaultAppConfiguration(Func<HttpContext, Task> testpath)
     {
         return app =>

--- a/test/ActiveLogin.Authentication.BankId.AspNetCore.Test/Helpers/TestBankIdLauncher.cs
+++ b/test/ActiveLogin.Authentication.BankId.AspNetCore.Test/Helpers/TestBankIdLauncher.cs
@@ -9,6 +9,6 @@ internal class TestBankIdLauncher : IBankIdLauncher
     public Task<BankIdLaunchInfo> GetLaunchInfoAsync(LaunchUrlRequest request)
     {
         // Always redirect back without user interaction in simulated mode
-        return Task.FromResult(new BankIdLaunchInfo(request.RedirectUrl, false, false, request.RedirectUrl));
+        return Task.FromResult(new BankIdLaunchInfo(request.RedirectUrl, false, false));
     }
 }

--- a/test/ActiveLogin.Authentication.BankId.Core.Test/BankIdRedirectUriTests.cs
+++ b/test/ActiveLogin.Authentication.BankId.Core.Test/BankIdRedirectUriTests.cs
@@ -1,0 +1,572 @@
+using System;
+
+using ActiveLogin.Authentication.BankId.Core.Launcher;
+
+using Xunit;
+
+namespace ActiveLogin.Authentication.BankId.Core.Test;
+
+/// <summary>
+/// Comprehensive tests for BankIdRedirectUrl.TryCreate covering:
+/// - URL validation (null, empty, whitespace)
+/// - URL encoding requirements
+/// - Maximum length validation (512 characters after encoding)
+/// - Browser-specific scheme replacement (iOS Chrome and Firefox)
+/// - Custom browser configuration override
+/// - URL fragment preservation (for nonce binding)
+/// - Different browser/OS combinations
+///
+/// Based on BankID Return URL specification:
+/// https://developers.bankid.com/getting-started/return-url
+/// </summary>
+public class BankIdRedirectUriTests
+{
+    #region Validation Tests
+
+    [Fact]
+    public void TryCreate_ShouldFail_WhenUrlIsNull()
+    {
+        // Act
+        var result = BankIdRedirectUrl.TryCreate(
+            null!,
+            config: null,
+            device: BankIdTestDevices.AnyDevice); // Device doesn't affect null validation
+
+        // Assert
+        result.Match(
+            _ => Assert.Fail("Expected failure but got success"),
+            error => Assert.Equal("Invalid URL", error)
+        );
+    }
+
+    [Fact]
+    public void TryCreate_ShouldFail_WhenUrlIsEmpty()
+    {
+        // Act
+        var result = BankIdRedirectUrl.TryCreate(
+            string.Empty,
+            config: null,
+            device: BankIdTestDevices.AnyDevice); // Device doesn't affect empty string validation
+
+        // Assert
+        result.Match(
+            _ => Assert.Fail("Expected failure but got success"),
+            error => Assert.Equal("Invalid URL", error)
+        );
+    }
+
+    [Fact]
+    public void TryCreate_ShouldFail_WhenUrlIsWhitespace()
+    {
+        // Act
+        var result = BankIdRedirectUrl.TryCreate(
+            "   ",
+            config: null,
+            device: BankIdTestDevices.AnyDevice); // Device doesn't affect whitespace validation
+
+        // Assert
+        Assert.True(result.IsFailure);
+        result.Match(
+            _ => Assert.Fail("Expected failure but got success"),
+            error => Assert.Equal("Invalid URL", error)
+        );
+    }
+
+    [Fact]
+    public void TryCreate_ShouldFail_WhenEncodedUrlExceeds512Characters()
+    {
+        // Arrange - Create URL that when encoded exceeds 512 chars
+        var longUrl = "https://example.com/" + new string('a', 500);
+
+        // Act
+        var result = BankIdRedirectUrl.TryCreate(
+            longUrl,
+            config: null,
+            device: BankIdTestDevices.AnyDevice); // Device doesn't affect length validation
+
+        // Assert
+        Assert.True(result.IsFailure);
+        result.Match(
+            _ => Assert.Fail("Expected failure but got success"),
+            error => Assert.Equal("URL must be at most 512 characters long", error)
+        );
+    }
+
+    [Fact]
+    public void TryCreate_ShouldSucceed_WhenEncodedUrlIsExactly512Characters()
+    {
+        // Arrange - Calculate URL that encodes to exactly 512 characters
+        // "https://example.com/" encodes to "https%3A%2F%2Fexample.com%2F" (28 chars)
+        // Need 512 - 28 = 484 more encoded characters
+        // 'a' encodes to 'a' (1 char), so we need 484 'a's
+        var url = "https://example.com/" + new string('a', 484);
+
+        // Act
+        var result = BankIdRedirectUrl.TryCreate(
+            url,
+            config: null,
+            device: BankIdTestDevices.AnyDevice); // Device doesn't affect length validation
+
+        // Assert
+        Assert.True(result.IsSuccess, "URL with exactly 512 encoded characters should succeed");
+        result.Match(
+            redirectUrl => Assert.Equal(512, redirectUrl.Url.Length),
+            _ => Assert.Fail("Expected success but got failure")
+        );
+    }
+
+    #endregion
+
+    #region URL Encoding Tests
+
+    [Fact]
+    public void TryCreate_ShouldEncodeUrl_UsingUriEscapeDataString()
+    {
+        // Arrange
+        var url = "https://example.com/path?param=value&other=test";
+
+        // Act
+        var result = BankIdRedirectUrl.TryCreate(
+            url,
+            config: null,
+            device: BankIdTestDevices.AnyDevice); // Device doesn't affect URL encoding
+
+        // Assert
+        result.Match(
+            redirectUrl => {
+                Assert.Equal(Uri.EscapeDataString(url), redirectUrl.Url);
+            },
+            _ => Assert.Fail("Expected success but got failure")
+        );
+    }
+
+    [Fact]
+    public void TryCreate_ShouldPreserveUrlFragment_ForNonceBinding()
+    {
+        // Arrange - Fragment with nonce as per BankID spec
+        var url = "https://example.com/login#nonce=session123";
+
+        // Act
+        var result = BankIdRedirectUrl.TryCreate(
+            url,
+            config: null,
+            device: BankIdTestDevices.AnyDevice); // Device doesn't affect fragment preservation
+
+        // Assert
+        result.Match(
+            redirectUrl => {
+                var decodedUrl = Uri.UnescapeDataString(redirectUrl.Url);
+                Assert.Contains("#nonce=session123", decodedUrl);
+            },
+            _ => Assert.Fail("Expected success but got failure")
+        );
+    }
+
+    [Fact]
+    public void TryCreate_ShouldEncodeSpecialCharacters()
+    {
+        // Arrange
+        var url = "https://example.com/path?special=åäö&chars=spaces here";
+
+        // Act
+        var result = BankIdRedirectUrl.TryCreate(
+            url,
+            config: null,
+            device: BankIdTestDevices.AnyDevice); // Device doesn't affect character encoding
+
+        // Assert
+        result.Match(
+            redirectUrl => {
+                Assert.DoesNotContain("å", redirectUrl.Url);
+                Assert.DoesNotContain("ä", redirectUrl.Url);
+                Assert.DoesNotContain("ö", redirectUrl.Url);
+                Assert.DoesNotContain(" ", redirectUrl.Url);
+            },
+            _ => Assert.Fail("Expected success but got failure")
+        );
+    }
+
+    #endregion
+
+    #region iOS Browser Scheme Replacement Tests
+
+    [Fact]
+    public void TryCreate_ShouldReplaceHttpsWithChromeScheme_ForIosChrome()
+    {
+        // Arrange
+        var url = "https://example.com/return?";
+
+        // Act
+        var result = BankIdRedirectUrl.TryCreate(
+            url,
+            config: null,
+            device: BankIdTestDevices.Mobile.Ios.Chrome); // Testing iOS Chrome-specific behavior
+
+        // Assert
+        result.Match(
+            redirectUrl => {
+                var decodedUrl = Uri.UnescapeDataString(redirectUrl.Url);
+                Assert.StartsWith("chromebrowser://", decodedUrl);
+            },
+            _ => Assert.Fail("Expected success but got failure")
+        );
+    }
+
+    [Fact]
+    public void TryCreate_ShouldReplaceHttpsWithFirefoxScheme_ForIosFirefox()
+    {
+        // Arrange
+        var url = "https://example.com/return";
+
+        // Act
+        var result = BankIdRedirectUrl.TryCreate(
+            url,
+            config: null,
+            device: BankIdTestDevices.Mobile.Ios.Firefox); // Testing iOS Firefox-specific behavior
+
+        // Assert
+        result.Match(
+            redirectUrl => {
+                var decodedUrl = Uri.UnescapeDataString(redirectUrl.Url);
+                Assert.StartsWith("firefox://", decodedUrl);
+            },
+            _ => Assert.Fail("Expected success but got failure")
+        );
+    }
+
+    [Fact]
+    public void TryCreate_ShouldNotReplaceScheme_ForIosSafari()
+    {
+        // Arrange
+        var url = "https://example.com/return";
+
+        // Act
+        var result = BankIdRedirectUrl.TryCreate(
+            url,
+            config: null,
+            device: BankIdTestDevices.Mobile.Ios.Safari); // Testing iOS Safari-specific behavior
+
+        // Assert
+        result.Match(
+            redirectUrl => {
+                var decodedUrl = Uri.UnescapeDataString(redirectUrl.Url);
+                Assert.StartsWith("https://", decodedUrl);
+            },
+            _ => Assert.Fail("Expected success but got failure")
+        );
+    }
+
+    [Fact]
+    public void TryCreate_ShouldNotReplaceScheme_ForIosEdge()
+    {
+        // Arrange
+        var url = "https://example.com/return";
+
+        // Act
+        var result = BankIdRedirectUrl.TryCreate(
+            url,
+            config: null,
+            device: BankIdTestDevices.Mobile.Ios.Edge); // Testing iOS Edge-specific behavior
+
+        // Assert
+        result.Match(
+            redirectUrl => {
+                var decodedUrl = Uri.UnescapeDataString(redirectUrl.Url);
+                Assert.StartsWith("https://", decodedUrl);
+            },
+            _ => Assert.Fail("Expected success but got failure")
+        );
+    }
+
+    #endregion
+
+    #region Android Browser Tests
+
+    [Theory]
+    [InlineData(nameof(BankIdTestDevices.Mobile.Android.Chrome))]
+    [InlineData(nameof(BankIdTestDevices.Mobile.Android.Firefox))]
+    [InlineData(nameof(BankIdTestDevices.Mobile.Android.Edge))]
+    [InlineData(nameof(BankIdTestDevices.Mobile.Android.SamsungInternet))]
+    [InlineData(nameof(BankIdTestDevices.Mobile.Android.Opera))]
+    public void TryCreate_ShouldNotReplaceScheme_ForAndroidBrowsers(string browserName)
+    {
+        // Arrange
+        var url = "https://example.com/return";
+        var device = browserName switch // Testing Android browser-specific behavior
+        {
+            nameof(BankIdTestDevices.Mobile.Android.Chrome) => BankIdTestDevices.Mobile.Android.Chrome,
+            nameof(BankIdTestDevices.Mobile.Android.Firefox) => BankIdTestDevices.Mobile.Android.Firefox,
+            nameof(BankIdTestDevices.Mobile.Android.Edge) => BankIdTestDevices.Mobile.Android.Edge,
+            nameof(BankIdTestDevices.Mobile.Android.SamsungInternet) => BankIdTestDevices.Mobile.Android.SamsungInternet,
+            nameof(BankIdTestDevices.Mobile.Android.Opera) => BankIdTestDevices.Mobile.Android.Opera,
+            _ => throw new ArgumentException($"Unknown browser: {browserName}")
+        };
+
+        // Act
+        var result = BankIdRedirectUrl.TryCreate(
+            url,
+            config: null,
+            device);
+
+        // Assert
+        result.Match(
+            redirectUrl => {
+                var decodedUrl = Uri.UnescapeDataString(redirectUrl.Url);
+                Assert.StartsWith("https://", decodedUrl);
+            },
+            _ => Assert.Fail($"Expected success for {browserName} but got failure")
+        );
+    }
+
+    #endregion
+
+    #region Desktop Browser Tests
+
+    [Theory]
+    [InlineData(nameof(BankIdTestDevices.Desktop.Windows_Chrome))]
+    [InlineData(nameof(BankIdTestDevices.Desktop.Windows_Edge))]
+    [InlineData(nameof(BankIdTestDevices.Desktop.Windows_Firefox))]
+    [InlineData(nameof(BankIdTestDevices.Desktop.MacOs_Safari))]
+    [InlineData(nameof(BankIdTestDevices.Desktop.MacOs_Chrome))]
+    public void TryCreate_ShouldNotReplaceScheme_ForDesktopBrowsers(string browserName)
+    {
+        // Arrange
+        var url = "https://example.com/return";
+        var device = browserName switch // Testing Desktop browser-specific behavior
+        {
+            nameof(BankIdTestDevices.Desktop.Windows_Chrome) => BankIdTestDevices.Desktop.Windows_Chrome,
+            nameof(BankIdTestDevices.Desktop.Windows_Edge) => BankIdTestDevices.Desktop.Windows_Edge,
+            nameof(BankIdTestDevices.Desktop.Windows_Firefox) => BankIdTestDevices.Desktop.Windows_Firefox,
+            nameof(BankIdTestDevices.Desktop.MacOs_Safari) => BankIdTestDevices.Desktop.MacOs_Safari,
+            nameof(BankIdTestDevices.Desktop.MacOs_Chrome) => BankIdTestDevices.Desktop.MacOs_Chrome,
+            _ => throw new ArgumentException($"Unknown browser: {browserName}")
+        };
+
+        // Act
+        var result = BankIdRedirectUrl.TryCreate(
+            url,
+            config: null,
+            device);
+
+        // Assert
+        result.Match(
+            redirectUrl => {
+                var decodedUrl = Uri.UnescapeDataString(redirectUrl.Url);
+                Assert.StartsWith("https://", decodedUrl);
+            },
+            _ => Assert.Fail($"Expected success for {browserName} but got failure")
+        );
+    }
+
+    #endregion
+
+    #region Custom Browser Configuration Tests
+
+    [Fact]
+    public void TryCreate_ShouldUseCustomBrowserScheme_WhenConfigProvided()
+    {
+        // Arrange
+        var url = "https://example.com/return";
+        var customScheme = new BrowserScheme("myapp://");
+        var config = new BankIdLauncherCustomBrowserConfig(
+            customScheme,
+            BrowserMightRequireUserInteractionToLaunch.Never
+        );
+
+        // Act
+        var result = BankIdRedirectUrl.TryCreate(
+            url,
+            config, // Testing custom config override
+            device: BankIdTestDevices.AnyDevice); // Device irrelevant when custom config provided
+
+        // Assert
+        result.Match(
+            redirectUrl => {
+                var decodedUrl = Uri.UnescapeDataString(redirectUrl.Url);
+                Assert.StartsWith("myapp://", decodedUrl);
+            },
+            _ => Assert.Fail("Expected success but got failure")
+        );
+    }
+
+    [Fact]
+    public void TryCreate_ShouldPreferCustomScheme_OverDefaultIosChromeScheme()
+    {
+        // Arrange
+        var url = "https://example.com/return";
+        var customScheme = new BrowserScheme("customapp://");
+        var config = new BankIdLauncherCustomBrowserConfig(
+            customScheme,
+            BrowserMightRequireUserInteractionToLaunch.Never
+        );
+
+        // Act
+        var result = BankIdRedirectUrl.TryCreate(
+            url,
+            config, // Testing that custom config takes precedence
+            device: BankIdTestDevices.Mobile.Ios.Chrome); // Would normally use chromebrowsers://
+
+        // Assert
+        result.Match(
+            redirectUrl => {
+                var decodedUrl = Uri.UnescapeDataString(redirectUrl.Url);
+                Assert.StartsWith("customapp://", decodedUrl);
+                Assert.DoesNotContain("chromebrowser://", decodedUrl);
+                Assert.DoesNotContain("https://", decodedUrl);
+            },
+            _ => Assert.Fail("Expected success but got failure")
+        );
+    }
+
+    [Fact]
+    public void TryCreate_ShouldHandleCustomSchemeWithTrailingSlashes()
+    {
+        // Arrange
+        var url = "https://example.com/return";
+        var customScheme = new BrowserScheme("myapp://");
+        var config = new BankIdLauncherCustomBrowserConfig(
+            customScheme,
+            BrowserMightRequireUserInteractionToLaunch.Never
+        );
+
+        // Act
+        var result = BankIdRedirectUrl.TryCreate(
+            url,
+            config, // Testing BrowserScheme trimming behavior
+            device: BankIdTestDevices.AnyDevice); // Device irrelevant when custom config provided
+
+        // Assert
+        result.Match(
+            redirectUrl => {
+                var decodedUrl = Uri.UnescapeDataString(redirectUrl.Url);
+                // BrowserScheme trims trailing :// so we expect clean scheme
+                Assert.StartsWith("myapp://", decodedUrl);
+            },
+            _ => Assert.Fail("Expected success but got failure")
+        );
+    }
+
+    #endregion
+
+    #region Case Sensitivity Tests
+
+    [Fact]
+    public void TryCreate_ShouldReplaceHttps_CaseInsensitive()
+    {
+        // Arrange - mixed case https
+        var url = "HTTPS://www.example.com/return";
+
+        // Act
+        var result = BankIdRedirectUrl.TryCreate(
+            url,
+            config: null,
+            device: BankIdTestDevices.Mobile.Ios.Chrome); // Testing case-insensitive replacement for iOS Chrome
+
+        // Assert
+        result.Match(
+            redirectUrl => {
+                var decodedUrl = Uri.UnescapeDataString(redirectUrl.Url);
+                Assert.Equal("chromebrowser://www.example.com/return", decodedUrl);
+                Assert.DoesNotContain("HTTPS://", decodedUrl);
+            },
+            _ => Assert.Fail("Expected success but got failure")
+        );
+    }
+
+    #endregion
+
+    #region Implicit Conversion Tests
+
+    [Fact]
+    public void ImplicitConversion_ShouldReturnUrl_WhenBankIdRedirectUrlIsNotNull()
+    {
+        // Arrange
+        var url = "https://example.com/return";
+        var result = BankIdRedirectUrl.TryCreate(
+            url,
+            config: null,
+            device: BankIdTestDevices.AnyDevice); // Device doesn't affect implicit conversion
+
+        // Act
+        string convertedUrl = null;
+        result.Match(
+            redirectUrl => convertedUrl = redirectUrl, // Implicit conversion to string
+            _ => Assert.Fail("Expected success")
+        );
+
+        // Assert
+        Assert.NotNull(convertedUrl);
+        Assert.Equal(Uri.EscapeDataString(url), convertedUrl);
+    }
+
+    [Fact]
+    public void ToString_ShouldReturnUrl()
+    {
+        // Arrange
+        var url = "https://example.com/return";
+        var result = BankIdRedirectUrl.TryCreate(
+            url,
+            config: null,
+            device: BankIdTestDevices.AnyDevice); // Device doesn't affect ToString
+
+        // Act & Assert
+        result.Match(
+            redirectUrl => {
+                Assert.Equal(redirectUrl.Url, redirectUrl.ToString());
+            },
+            _ => Assert.Fail("Expected success")
+        );
+    }
+
+    #endregion
+
+    #region Real-World Scenario Tests
+
+    [Fact]
+    public void TryCreate_ShouldHandleTypicalLoginUrl_WithNonce()
+    {
+        // Arrange - Typical scenario from BankID docs
+        var url = "https://www.example.com/login#nonce=abc123def456";
+
+        // Act
+        var result = BankIdRedirectUrl.TryCreate(
+            url,
+            config: null,
+            device: BankIdTestDevices.AnyDevice); // Device doesn't matter for URL structure test
+
+        // Assert
+        result.Match(
+            redirectUrl => {
+                Assert.NotNull(redirectUrl.Url);
+                var decodedUrl = Uri.UnescapeDataString(redirectUrl.Url);
+                Assert.Contains("login", decodedUrl);
+                Assert.Contains("nonce=abc123def456", decodedUrl);
+            },
+            _ => Assert.Fail("Expected success but got failure")
+        );
+    }
+
+    [Fact]
+    public void TryCreate_ShouldHandleLocalhost_WithPort()
+    {
+        // Arrange - Development scenario
+        var url = "https://localhost:5001/ActiveLogin/BankId/Auth/Init?returnUrl=/secure";
+
+        // Act
+        var result = BankIdRedirectUrl.TryCreate(
+            url,
+            config: null,
+            device: BankIdTestDevices.AnyDevice); // Device doesn't affect localhost handling
+
+        // Assert
+        result.Match(
+            redirectUrl => {
+                var decodedUrl = Uri.UnescapeDataString(redirectUrl.Url);
+                Assert.Contains("localhost:5001", decodedUrl);
+            },
+            _ => Assert.Fail("Expected success but got failure")
+        );
+    }
+
+    #endregion
+}

--- a/test/ActiveLogin.Authentication.BankId.Core.Test/BankIdTestDevices.cs
+++ b/test/ActiveLogin.Authentication.BankId.Core.Test/BankIdTestDevices.cs
@@ -1,0 +1,74 @@
+using ActiveLogin.Authentication.BankId.Core.SupportedDevice;
+
+namespace ActiveLogin.Authentication.BankId.Core.Test;
+
+/// <summary>
+/// Shared test fixture providing predefined BankIdSupportedDevice instances
+/// for use across unit tests. Covers the major browsers and platforms documented
+/// in the BankID integration guide.
+/// </summary>
+public static class BankIdTestDevices
+{
+    /// <summary>
+    /// Use this when the specific device doesn't matter for the test scenario.
+    /// Makes it clear that device selection is arbitrary and not part of what's being tested.
+    /// </summary>
+    public static BankIdSupportedDevice AnyDevice => Desktop.Windows_Edge;
+
+    public static class Desktop
+    {
+        public static BankIdSupportedDevice Windows_Edge =>
+            new(BankIdSupportedDeviceType.Desktop, BankIdSupportedDeviceOs.Windows, BankIdSupportedDeviceBrowser.Edge, new BankIdSupportedDeviceOsVersion(10));
+
+        public static BankIdSupportedDevice Windows_Chrome =>
+            new(BankIdSupportedDeviceType.Desktop, BankIdSupportedDeviceOs.Windows, BankIdSupportedDeviceBrowser.Chrome, new BankIdSupportedDeviceOsVersion(10));
+
+        public static BankIdSupportedDevice Windows_Firefox =>
+            new(BankIdSupportedDeviceType.Desktop, BankIdSupportedDeviceOs.Windows, BankIdSupportedDeviceBrowser.Firefox, new BankIdSupportedDeviceOsVersion(10));
+
+        public static BankIdSupportedDevice MacOs_Safari =>
+            new(BankIdSupportedDeviceType.Desktop, BankIdSupportedDeviceOs.MacOs, BankIdSupportedDeviceBrowser.Safari, new BankIdSupportedDeviceOsVersion(10, 15));
+
+        public static BankIdSupportedDevice MacOs_Chrome =>
+            new(BankIdSupportedDeviceType.Desktop, BankIdSupportedDeviceOs.MacOs, BankIdSupportedDeviceBrowser.Chrome, new BankIdSupportedDeviceOsVersion(10, 15));
+    }
+
+    public static class Mobile
+    {
+        public static class Android
+        {
+            public static BankIdSupportedDevice Chrome =>
+                new(BankIdSupportedDeviceType.Mobile, BankIdSupportedDeviceOs.Android, BankIdSupportedDeviceBrowser.Chrome, new BankIdSupportedDeviceOsVersion(10));
+
+            public static BankIdSupportedDevice Edge =>
+                new(BankIdSupportedDeviceType.Mobile, BankIdSupportedDeviceOs.Android, BankIdSupportedDeviceBrowser.Edge, new BankIdSupportedDeviceOsVersion(10));
+
+            public static BankIdSupportedDevice SamsungInternet =>
+                new(BankIdSupportedDeviceType.Mobile, BankIdSupportedDeviceOs.Android, BankIdSupportedDeviceBrowser.SamsungBrowser, new BankIdSupportedDeviceOsVersion(10));
+
+            public static BankIdSupportedDevice Firefox =>
+                new(BankIdSupportedDeviceType.Mobile, BankIdSupportedDeviceOs.Android, BankIdSupportedDeviceBrowser.Firefox, new BankIdSupportedDeviceOsVersion(10));
+
+            public static BankIdSupportedDevice Opera =>
+                new(BankIdSupportedDeviceType.Mobile, BankIdSupportedDeviceOs.Android, BankIdSupportedDeviceBrowser.Opera, new BankIdSupportedDeviceOsVersion(10));
+        }
+
+        public static class Ios
+        {
+            public static BankIdSupportedDevice Safari =>
+                new(BankIdSupportedDeviceType.Mobile, BankIdSupportedDeviceOs.Ios, BankIdSupportedDeviceBrowser.Safari, new BankIdSupportedDeviceOsVersion(14));
+
+            public static BankIdSupportedDevice Chrome =>
+                new(BankIdSupportedDeviceType.Mobile, BankIdSupportedDeviceOs.Ios, BankIdSupportedDeviceBrowser.Chrome, new BankIdSupportedDeviceOsVersion(14));
+
+            public static BankIdSupportedDevice Firefox =>
+                new(BankIdSupportedDeviceType.Mobile, BankIdSupportedDeviceOs.Ios, BankIdSupportedDeviceBrowser.Firefox, new BankIdSupportedDeviceOsVersion(14));
+
+            public static BankIdSupportedDevice Edge =>
+                new(BankIdSupportedDeviceType.Mobile, BankIdSupportedDeviceOs.Ios, BankIdSupportedDeviceBrowser.Edge, new BankIdSupportedDeviceOsVersion(14));
+
+            public static BankIdSupportedDevice Opera =>
+                new(BankIdSupportedDeviceType.Mobile, BankIdSupportedDeviceOs.Ios, BankIdSupportedDeviceBrowser.Opera, new BankIdSupportedDeviceOsVersion(14));
+        }
+    }
+}

--- a/test/ActiveLogin.Authentication.BankId.Core.Test/Helpers/TestBankIdLauncher.cs
+++ b/test/ActiveLogin.Authentication.BankId.Core.Test/Helpers/TestBankIdLauncher.cs
@@ -9,6 +9,6 @@ internal class TestBankIdLauncher : IBankIdLauncher
     public Task<BankIdLaunchInfo> GetLaunchInfoAsync(LaunchUrlRequest request)
     {
         // Always redirect back without user interaction in simulated mode
-        return Task.FromResult(new BankIdLaunchInfo(request.RedirectUrl, false, false, request.RedirectUrl));
+        return Task.FromResult(new BankIdLaunchInfo(request.RedirectUrl, false, false));
     }
 }


### PR DESCRIPTION
This PR ensures that for all same-device scenarios we send a RedirectUrl to BankId.
This sets the groundwork needed for sending a nonce included in the redirectUrl (which is strongly recommended).

Logic for constructing a valid RedirectUrl is found in BankIdRedirectUrl. 

This needs extensive testing, the automated testing is not enough to ensure expected behavior. Using manual testing we can extend the tests based on our observations.