### PR TITLE
Adhere to more modern BankID recommendations for opening in mobile device

### DIFF
--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/Client/activelogin-main.ts
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/Client/activelogin-main.ts
@@ -109,6 +109,15 @@ function activeloginInit(configuration: IBankIdUiScriptConfiguration, initState:
     var flowIsCancelledByUser = false;
     var flowIsFinished = false;
 
+    function launchBankIdApp(url: string) {
+        // Use BankID recommended approach for launching the app
+        // See: https://developers.bankid.com/getting-started/autostart
+        const link = document.createElement("a");
+        link.href = url;
+        link.referrerPolicy = "origin";
+        link.click();
+    }
+
     function enableCancelButton(requestVerificationToken: string, cancelUrl: string, orderRef: string = null) {
         var onCancelButtonClick = (event: Event) => {
             cancel(requestVerificationToken, cancelUrl, orderRef);
@@ -132,7 +141,7 @@ function activeloginInit(configuration: IBankIdUiScriptConfiguration, initState:
 
                     if (data.deviceMightRequireUserInteractionToLaunchBankIdApp) {
                         var startBankIdAppButtonOnClick = (event: Event) => {
-                            window.location.href = data.redirectUri;
+                            launchBankIdApp(data.redirectUri);
                             hide(startBankIdAppButtonElement);
                             event.target.removeEventListener("click", startBankIdAppButtonOnClick);
                         };
@@ -140,7 +149,7 @@ function activeloginInit(configuration: IBankIdUiScriptConfiguration, initState:
 
                         show(startBankIdAppButtonElement);
                     } else {
-                        window.location.href = data.redirectUri;
+                        launchBankIdApp(data.redirectUri);
                     }
                 }
 


### PR DESCRIPTION
PR fixes #533

We have been able to reproduce issue with Edge+Intune that are security restricted, this fixes the issue. It also emulates the behaviour we see on test.bankid.com and follows the BankID documentation. If I understand correctly, the No such orders is when it thinks it has created a request to BankID(using bankid://) but it has been blocked, so a cancel or other action without a real order gives the "no such order" message.

Stops use of bankid:// on mobile devices  that are often security restricted. Instead uses the https://app.bankid.com,
Source: https://developers.bankid.com/getting-started/autostart 
Quote: "To open the Mobile BankID app from a browser on a mobile device, you should use unversal links for iOS and app links for Android. "

Displays fallback button by default on mobile devices:
Source: https://developers.bankid.com/resources/ui-guide-mobile
Quote: "4. Promt user to open BankID. The BankID app should be opened automatically using [autostart](https://developers.bankid.com/getting-started/autostart). **However, in case this fails for some reason, the user should be asked to open the app manually.**"


