### PR TITLE
Change default client certificate format from PFX to P12.

### DIFF
--- a/BREAKINGCHANGES.md
+++ b/BREAKINGCHANGES.md
@@ -34,13 +34,19 @@ If you are upgrading from an earlier version, you must update any application or
 
 When loading embedded BankID certificates (client test certificate and root certificates for both test and production), we now use `X509KeyStorageFlags.DefaultKeySet` by default.
 
-If this change causes issues in your environment, you can override the `X509KeyStorageFlags` used for the client test certificate. See [the documention](https://docs.activelogin.net/articles/bankid.html#test-environment) for information about how it is done.
+If this change causes issues in your environment, you can override the `X509KeyStorageFlags` used for the client test certificate. See [the documentation](https://docs.activelogin.net/articles/bankid.html#test-environment) for information about how it is done.
 
 ### Loading client BankID certificate from Azure Key Vault
 
 When loading the client BankID certificate from Azure Key Vault, we now use `X509KeyStorageFlags.DefaultKeySet` by default.
 
-If this causes issues in your environment, it is possible to override the `X509KeyStorageFlags` used when loading the certificate. See [the documention](https://docs.activelogin.net/articles/bankid.html#using-client-certificate-from-azure-keyvault) for information about how it is done.
+If this causes issues in your environment, it is possible to override the `X509KeyStorageFlags` used when loading the certificate. See [the documentation](https://docs.activelogin.net/articles/bankid.html#using-client-certificate-from-azure-keyvault) for information about how it is done.
+
+### Format of client BankID certificate
+
+The default file format for the client BankID certificate in the test environment has changed. Instead of `FPTestcert5_20240610-legacy.pfx`, the default is now `FPTestcert5_20240610.p12`.
+
+This can be overridden if required. See the [documentation](https://docs.activelogin.net/articles/bankid.html#specify-client-certificate-format) for further information.
 
 ---
 
@@ -353,7 +359,7 @@ When implementing the animated QR code, we have had to update the client side sc
 
 ### Use DefaultAzureCredentials when accessing KeyVault
 
-If using Azure KeyVault for your certificate, we have made chamges to how you authenticate/access that. See [the documention](https://docs.activelogin.net/articles/bankid.html#keyvault-credentials) for how it should be configured now.
+If using Azure KeyVault for your certificate, we have made chamges to how you authenticate/access that. See [the documentation](https://docs.activelogin.net/articles/bankid.html#keyvault-credentials) for how it should be configured now.
 
 ### Drop support for GrandID
 

--- a/docs/articles/bankid.md
+++ b/docs/articles/bankid.md
@@ -236,7 +236,7 @@ services
 
 #### Specify client certificate format
 
-BankId provides the client certificate for the test environment in three different versions FPTestcert5_20240610.p12, FPTestcert5_20240610.pem and FPTestcert5_20240610-legacy.pfx. Use `FPTestcert5_20240610.p12` for newer applications and environments that support modern encryption methods. Use `FPTestcert5_20240610.pem` if your application requires PEM format. Use `FPTestcert5_20240610-legacy.pfx ` for older applications requiring older algorithms such as Windows Server earlier versions than 2022. The format of the client certificate can be configured. By default `FPTestcert5_20240610-legacy.p12 `is used.
+BankId provides the client certificate for the test environment in three different versions FPTestcert5_20240610.p12, FPTestcert5_20240610.pem and FPTestcert5_20240610-legacy.pfx. Use `FPTestcert5_20240610.p12` for newer applications and environments that support modern encryption methods. Use `FPTestcert5_20240610.pem` if your application requires PEM format. Use `FPTestcert5_20240610-legacy.pfx` for older applications requiring older algorithms such as Windows Server earlier versions than 2022. The format of the client certificate can be configured. By default `FPTestcert5_20240610-legacy.p12 `is used.
 
 ```csharp
 services

--- a/docs/articles/bankid.md
+++ b/docs/articles/bankid.md
@@ -236,7 +236,7 @@ services
 
 #### Specify client certificate format
 
-BankId provides the client certificate for the test environment in three different versions FPTestcert5_20240610.p12, FPTestcert5_20240610.pem and FPTestcert5_20240610-legacy.pfx. Use `FPTestcert5_20240610.p12` for newer applications and environments that support modern encryption methods. Use `FPTestcert5_20240610.pem` if your application requires PEM format. Use `FPTestcert5_20240610-legacy.pfx ` for older applications requiring older algorithms such as Windows Server earlier versions than 2022. The format of the client certificate can be configured. By default `FPTestcert5_20240610-legacy.pfx `is used.
+BankId provides the client certificate for the test environment in three different versions FPTestcert5_20240610.p12, FPTestcert5_20240610.pem and FPTestcert5_20240610-legacy.pfx. Use `FPTestcert5_20240610.p12` for newer applications and environments that support modern encryption methods. Use `FPTestcert5_20240610.pem` if your application requires PEM format. Use `FPTestcert5_20240610-legacy.pfx ` for older applications requiring older algorithms such as Windows Server earlier versions than 2022. The format of the client certificate can be configured. By default `FPTestcert5_20240610-legacy.p12 `is used.
 
 ```csharp
 services

--- a/src/ActiveLogin.Authentication.BankId.Core/BankIdCertificates.cs
+++ b/src/ActiveLogin.Authentication.BankId.Core/BankIdCertificates.cs
@@ -22,7 +22,7 @@ internal static class BankIdCertificates
         TestCertificateFormat.P12 => GetCertFromResourceStream(BankIdApiClientCertificateTestP12, keyStorageFlags),
         TestCertificateFormat.PEM => GetPemCertFromResourceStream(BankIdApiClientCertificateTestPem),
         TestCertificateFormat.PFX => GetCertFromResourceStream(BankIdApiClientCertificateTestPfx, keyStorageFlags),
-        _ => GetCertFromResourceStream(BankIdApiClientCertificateTestPfx, keyStorageFlags)
+        _ => GetCertFromResourceStream(BankIdApiClientCertificateTestP12, keyStorageFlags)
     };
 
     private static X509Certificate2 GetCertFromResourceStream(CertificateResource resource, X509KeyStorageFlags keyStorageFlags = X509KeyStorageFlags.DefaultKeySet)

--- a/src/ActiveLogin.Authentication.BankId.Core/IBankIdBuilderExtensions.cs
+++ b/src/ActiveLogin.Authentication.BankId.Core/IBankIdBuilderExtensions.cs
@@ -217,7 +217,7 @@ public static class IBankIdBuilderExtensions
         this IBankIdBuilder builder,
         bool useBankIdRootCertificate = true,
         bool useBankIdClientCertificate = true,
-        TestCertificateFormat clientCertificateFormat = TestCertificateFormat.PFX,
+        TestCertificateFormat clientCertificateFormat = TestCertificateFormat.P12,
         X509KeyStorageFlags keyStorageFlags = X509KeyStorageFlags.DefaultKeySet
     )
     {


### PR DESCRIPTION
For the BankID client test certificate embedded in Active Login, use file format p12 by default instead if pfx. 
