### PR TITLE
Made the ctor public.

### DIFF
--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/ClaimsTransformation/BankIdClaimsTransformationContext.cs
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/ClaimsTransformation/BankIdClaimsTransformationContext.cs
@@ -7,7 +7,7 @@ namespace ActiveLogin.Authentication.BankId.AspNetCore.ClaimsTransformation;
 
 public class BankIdClaimsTransformationContext
 {
-    internal BankIdClaimsTransformationContext(BankIdAuthOptions bankIdAuthOptions, string bankIdOrderRef, string personalIdentityNumber, string name, string givenName, string surname, CompletionData bankIdCompletionData)
+    public BankIdClaimsTransformationContext(BankIdAuthOptions bankIdAuthOptions, string bankIdOrderRef, string personalIdentityNumber, string name, string givenName, string surname, CompletionData bankIdCompletionData)
     {
         BankIdAuthOptions = bankIdAuthOptions;
 


### PR DESCRIPTION
This PR fixes #541.

These things have been implemented (when relevant):

- [x] The constructor of BankIdClaimsTransformationContext is made public
