### PR TITLE
Fix docs workflow by using modern docfx tool and .NET 10 SDK

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,17 +23,15 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
-    - name: Setup .NET 6.0
-      uses: actions/setup-dotnet@v1
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 10.0.x
 
     - name: Setup DocFX
-      uses: crazy-max/ghaction-chocolatey@v1
-      with:
-        args: install docfx
+      run: dotnet tool update -g docfx
 
     - name: Copy *.md to docs
       run: Copy-Item -Path ./*.md -Destination ./docs/articles


### PR DESCRIPTION
The docs CI failed because the outdated Chocolatey docfx and .NET 6 SDK could not load the .NET 10 projects (XMakeElements type initializer error). 

Fixes #549 

High level overview of this PR:

- [x] Switch to the docfx .NET global tool and install the .NET 10 SDK.

These things have been implemented (when relevant):

- [x] Code written
~~- [ ] Test added~~
~~- [ ] Documentation updated / written~~
