### PR TITLE
Fix deprecated build and release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
           artifactName: activelogin-authentication-samples-ubuntu
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Create file BankIdRootCertificate-Prod.crt
         run: |
@@ -116,7 +116,7 @@ jobs:
           bankIdRootCert_test: ${{ secrets.BANKIDROOTCERTIFICATE_TEST_FILEB64 }}
 
       - name: 'Install: .NET Core SDK'
-        uses: actions/setup-dotnet@v1.7.2
+        uses: actions/setup-dotnet@v4
 
       - name: Dotnet publish
         run : |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: GitHubPackages
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      actions: read
+      packages: write
     strategy:
       matrix:
         package:
@@ -25,28 +28,11 @@ jobs:
         - ActiveLogin.Authentication.BankId.UAParser
     steps:
       - name: 'Download artifact'
-        uses: actions/github-script@v5
+        uses: actions/download-artifact@v4
         with:
-          script: |
-            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               run_id: context.payload.workflow_run.id,
-            });
-            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == "activelogin-authentication-nuget-windows"
-            })[0];
-            let download = await github.rest.actions.downloadArtifact({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               artifact_id: matchArtifact.id,
-               archive_format: 'zip',
-            });
-            let fs = require('fs');
-            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/artifact.zip`, Buffer.from(download.data));
-
-      - name: 'Unzip artifact'
-        run: unzip artifact.zip
+          name: activelogin-authentication-nuget-windows
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v4


### PR DESCRIPTION
**High level overview of this PR:**
Fixes #551 

- Fix the failing Release workflow by replacing the broken actions/github-script@v5 artifact download with actions/download-artifact@v4
- Add the required permissions (actions: read, packages: write) to the release job and remove the now-redundant manual unzip step
- Bonus: Update the remaining deprecated actions in the build_samples job (actions/checkout@v2 → @v4, actions/setup-dotnet@v1.7.2 → @v4)

**These things have been implemented (when relevant):**
 - [x] Code written
