### PR TITLE
Add configurable collect states to the simulated BankID environment

### DIFF
--- a/docs/articles/bankid.md
+++ b/docs/articles/bankid.md
@@ -225,7 +225,7 @@ services
     });
 ```
 
-The `AllCollectStates` sequence can be used to verify that the UI handles the different successful collect hint codes and text lengths.
+The `AllSuccessfulCollectStates` sequence can be used to verify that the UI handles the different successful collect hint codes and text lengths. It intentionally does not include failed terminal states, so the simulated authentication can complete successfully.
 
 ```csharp
 services
@@ -233,7 +233,7 @@ services
     {
         bankId.UseSimulatedEnvironment(options =>
         {
-            options.CollectStates = BankIdSimulatedAppApiClient.AllCollectStates;
+            options.CollectStates = BankIdSimulatedAppApiClient.AllSuccessfulCollectStates;
         });
     });
 ```
@@ -255,7 +255,7 @@ services
     });
 ```
 
-These examples require the `ActiveLogin.Authentication.BankId.Api` and `ActiveLogin.Authentication.BankId.Core` namespaces. The simulated client also applies a response delay to mimic the real flow. Set `Delay` on the resolved `BankIdSimulatedAppApiClient` when a test needs to remove that delay completely.
+These examples require the `ActiveLogin.Authentication.BankId.Api` and `ActiveLogin.Authentication.BankId.Core` namespaces. The simulated client also applies a response delay to mimic the real flow. Delay is not configured by `UseSimulatedEnvironment`; if a test needs to remove it, resolve the registered `BankIdSimulatedAppApiClient` from dependency injection and set its `Delay` property to `TimeSpan.Zero`.
 
 
 ### Test environment

--- a/docs/articles/bankid.md
+++ b/docs/articles/bankid.md
@@ -210,6 +210,54 @@ services
 ```
 
 
+### Simulated environment with custom collect states
+
+The simulated environment uses a normal collect flow by default. For automated tests, a faster flow can be selected. The `FastCollectStates` sequence contains only the states needed to reach a successful result.
+
+```csharp
+services
+    .AddBankId(bankId =>
+    {
+        bankId.UseSimulatedEnvironment(options =>
+        {
+            options.CollectStates = BankIdSimulatedAppApiClient.FastCollectStates;
+        });
+    });
+```
+
+The `AllCollectStates` sequence can be used to verify that the UI handles the different successful collect hint codes and text lengths.
+
+```csharp
+services
+    .AddBankId(bankId =>
+    {
+        bankId.UseSimulatedEnvironment(options =>
+        {
+            options.CollectStates = BankIdSimulatedAppApiClient.AllCollectStates;
+        });
+    });
+```
+
+For a specialized test, provide your own sequence. The final state should have `CollectStatus.Complete` so that the simulated authentication can finish successfully.
+
+```csharp
+services
+    .AddBankId(bankId =>
+    {
+        bankId.UseSimulatedEnvironment(options =>
+        {
+            options.CollectStates = new List<BankIdSimulatedAppApiClient.CollectState>
+            {
+                new(CollectStatus.Pending, CollectHintCode.Started),
+                new(CollectStatus.Complete, CollectHintCode.UserSign)
+            };
+        });
+    });
+```
+
+These examples require the `ActiveLogin.Authentication.BankId.Api` and `ActiveLogin.Authentication.BankId.Core` namespaces. The simulated client also applies a response delay to mimic the real flow. Set `Delay` on the resolved `BankIdSimulatedAppApiClient` when a test needs to remove that delay completely.
+
+
 ### Test environment
 
 This will use the real REST API for BankID, connecting to the Test environment.

--- a/docs/articles/bankid.md
+++ b/docs/articles/bankid.md
@@ -225,18 +225,7 @@ services
     });
 ```
 
-The `AllSuccessfulCollectStates` sequence can be used to verify that the UI handles the different successful collect hint codes and text lengths. It intentionally does not include failed terminal states, so the simulated authentication can complete successfully.
-
-```csharp
-services
-    .AddBankId(bankId =>
-    {
-        bankId.UseSimulatedEnvironment(options =>
-        {
-            options.CollectStates = BankIdSimulatedAppApiClient.AllSuccessfulCollectStates;
-        });
-    });
-```
+The `AllSuccessfulCollectStates` sequence can be used to verify that the UI handles the different successful collect hint codes and text lengths. It intentionally does not include failed terminal states, so the simulated authentication can complete successfully. Set it with `options.CollectStates = BankIdSimulatedAppApiClient.AllSuccessfulCollectStates;`.
 
 For a specialized test, provide your own sequence. The final state should have `CollectStatus.Complete` so that the simulated authentication can finish successfully.
 

--- a/src/ActiveLogin.Authentication.BankId.Api/BankIdSimulatedAppApiClient.cs
+++ b/src/ActiveLogin.Authentication.BankId.Api/BankIdSimulatedAppApiClient.cs
@@ -43,7 +43,7 @@ public class BankIdSimulatedAppApiClient : IBankIdAppApiClient
     /// <summary>
     /// Gets a new collect-state sequence that covers the UI-relevant successful hint codes.
     /// </summary>
-    public static List<CollectState> AllCollectStates => new()
+    public static List<CollectState> AllSuccessfulCollectStates => new()
     {
         new CollectState(CollectStatus.Pending, CollectHintCode.OutstandingTransaction),
         new CollectState(CollectStatus.Pending, CollectHintCode.NoClient),
@@ -97,13 +97,18 @@ public class BankIdSimulatedAppApiClient : IBankIdAppApiClient
 
     public BankIdSimulatedAppApiClient(string givenName, string surname, string name, string personalIdentityNumber, string bankIdIssueDate, string uniqueHardwareId, List<CollectState> collectStates)
     {
+        if (collectStates == null || collectStates.Count == 0)
+        {
+            throw new ArgumentException("At least one collect state must be configured.", nameof(collectStates));
+        }
+
         _givenName = givenName;
         _surname = surname;
         _name = name;
         _personalIdentityNumber = personalIdentityNumber;
         _bankIdIssueDate = bankIdIssueDate;
         _uniqueHardwareId = uniqueHardwareId;
-        _collectStates = collectStates;
+        _collectStates = new List<CollectState>(collectStates);
     }
 
     public TimeSpan Delay

--- a/src/ActiveLogin.Authentication.BankId.Api/BankIdSimulatedAppApiClient.cs
+++ b/src/ActiveLogin.Authentication.BankId.Api/BankIdSimulatedAppApiClient.cs
@@ -97,7 +97,12 @@ public class BankIdSimulatedAppApiClient : IBankIdAppApiClient
 
     public BankIdSimulatedAppApiClient(string givenName, string surname, string name, string personalIdentityNumber, string bankIdIssueDate, string uniqueHardwareId, List<CollectState> collectStates)
     {
-        if (collectStates == null || collectStates.Count == 0)
+        if (collectStates == null)
+        {
+            throw new ArgumentNullException(nameof(collectStates));
+        }
+
+        if (collectStates.Count == 0)
         {
             throw new ArgumentException("At least one collect state must be configured.", nameof(collectStates));
         }

--- a/src/ActiveLogin.Authentication.BankId.Api/BankIdSimulatedAppApiClient.cs
+++ b/src/ActiveLogin.Authentication.BankId.Api/BankIdSimulatedAppApiClient.cs
@@ -26,6 +26,34 @@ public class BankIdSimulatedAppApiClient : IBankIdAppApiClient
         new CollectState(CollectStatus.Complete, CollectHintCode.UserSign)
     };
 
+    /// <summary>
+    /// Gets a new collect-state sequence that resembles a normal authentication flow.
+    /// </summary>
+    public static List<CollectState> NormalCollectStates => new(DefaultCollectStates);
+
+    /// <summary>
+    /// Gets a new collect-state sequence with the fewest states needed to complete authentication.
+    /// </summary>
+    public static List<CollectState> FastCollectStates => new()
+    {
+        new CollectState(CollectStatus.Pending, CollectHintCode.OutstandingTransaction),
+        new CollectState(CollectStatus.Complete, CollectHintCode.UserSign)
+    };
+
+    /// <summary>
+    /// Gets a new collect-state sequence that covers the UI-relevant successful hint codes.
+    /// </summary>
+    public static List<CollectState> AllCollectStates => new()
+    {
+        new CollectState(CollectStatus.Pending, CollectHintCode.OutstandingTransaction),
+        new CollectState(CollectStatus.Pending, CollectHintCode.NoClient),
+        new CollectState(CollectStatus.Pending, CollectHintCode.Started),
+        new CollectState(CollectStatus.Pending, CollectHintCode.UserMrtd),
+        new CollectState(CollectStatus.Pending, CollectHintCode.UserCallConfirm),
+        new CollectState(CollectStatus.Pending, CollectHintCode.UserSign),
+        new CollectState(CollectStatus.Complete, CollectHintCode.UserSign)
+    };
+
     private readonly string _givenName;
     private readonly string _surname;
     private readonly string _name;
@@ -38,7 +66,7 @@ public class BankIdSimulatedAppApiClient : IBankIdAppApiClient
     private TimeSpan _delay = TimeSpan.FromMilliseconds(250);
 
     public BankIdSimulatedAppApiClient()
-        : this(DefaultCollectStates)
+        : this(NormalCollectStates)
     {
     }
 
@@ -53,7 +81,7 @@ public class BankIdSimulatedAppApiClient : IBankIdAppApiClient
     }
 
     public BankIdSimulatedAppApiClient(string givenName, string surname, string personalIdentityNumber)
-        : this(givenName, surname, personalIdentityNumber, DefaultCollectStates)
+        : this(givenName, surname, personalIdentityNumber, NormalCollectStates)
     {
     }
 
@@ -63,7 +91,7 @@ public class BankIdSimulatedAppApiClient : IBankIdAppApiClient
     }
 
     public BankIdSimulatedAppApiClient(string givenName, string surname, string name, string personalIdentityNumber)
-        : this(givenName, surname, name, personalIdentityNumber, DefaultBankIdIssueDate, DefaultUniqueHardwareId, DefaultCollectStates)
+        : this(givenName, surname, name, personalIdentityNumber, DefaultBankIdIssueDate, DefaultUniqueHardwareId, NormalCollectStates)
     {
     }
 

--- a/src/ActiveLogin.Authentication.BankId.AspNetCore/README.md
+++ b/src/ActiveLogin.Authentication.BankId.AspNetCore/README.md
@@ -26,6 +26,8 @@ services
     });
 ```
 
+For faster automated tests, configure the simulated environment with `BankIdSimulatedAppApiClient.FastCollectStates`. See the [simulated environment documentation](../../docs/articles/bankid.md) for custom collect-state examples.
+
 ### Production
 
 ```csharp

--- a/src/ActiveLogin.Authentication.BankId.Core/BankIdSimulatedEnvironmentOptions.cs
+++ b/src/ActiveLogin.Authentication.BankId.Core/BankIdSimulatedEnvironmentOptions.cs
@@ -1,0 +1,14 @@
+using ActiveLogin.Authentication.BankId.Api;
+
+namespace ActiveLogin.Authentication.BankId.Core;
+
+/// <summary>
+/// Configuration for the simulated BankID environment.
+/// </summary>
+public sealed class BankIdSimulatedEnvironmentOptions
+{
+    /// <summary>
+    /// The sequence of states returned by collect calls.
+    /// </summary>
+    public List<BankIdSimulatedAppApiClient.CollectState> CollectStates { get; set; } = BankIdSimulatedAppApiClient.NormalCollectStates;
+}

--- a/src/ActiveLogin.Authentication.BankId.Core/IBankIdBuilderExtensions.cs
+++ b/src/ActiveLogin.Authentication.BankId.Core/IBankIdBuilderExtensions.cs
@@ -287,10 +287,6 @@ public static class IBankIdBuilderExtensions
 
         var options = new BankIdSimulatedEnvironmentOptions();
         configure(options);
-        if (options.CollectStates == null || options.CollectStates.Count == 0)
-        {
-            throw new ArgumentException("At least one collect state must be configured.", nameof(configure));
-        }
 
         var collectStates = new List<BankIdSimulatedAppApiClient.CollectState>(options.CollectStates);
 

--- a/src/ActiveLogin.Authentication.BankId.Core/IBankIdBuilderExtensions.cs
+++ b/src/ActiveLogin.Authentication.BankId.Core/IBankIdBuilderExtensions.cs
@@ -267,7 +267,33 @@ public static class IBankIdBuilderExtensions
     public static IBankIdBuilder UseSimulatedEnvironment(this IBankIdBuilder builder)
     {
         return UseSimulatedEnvironment(builder,
-            x => new BankIdSimulatedAppApiClient(),
+            x => new BankIdSimulatedAppApiClient(BankIdSimulatedAppApiClient.NormalCollectStates),
+            x => new BankIdSimulatedVerifyApiClient()
+        );
+    }
+
+    /// <summary>
+    /// Use simulated (in memory) environment. To be used for automated testing.
+    /// </summary>
+    /// <param name="builder"></param>
+    /// <param name="configure">Configures the collect-state sequence.</param>
+    /// <returns></returns>
+    public static IBankIdBuilder UseSimulatedEnvironment(this IBankIdBuilder builder, Action<BankIdSimulatedEnvironmentOptions> configure)
+    {
+        if (configure == null)
+        {
+            throw new ArgumentNullException(nameof(configure));
+        }
+
+        var options = new BankIdSimulatedEnvironmentOptions();
+        configure(options);
+        if (options.CollectStates == null || options.CollectStates.Count == 0)
+        {
+            throw new ArgumentException("At least one collect state must be configured.", nameof(configure));
+        }
+
+        return UseSimulatedEnvironment(builder,
+            x => new BankIdSimulatedAppApiClient(options.CollectStates),
             x => new BankIdSimulatedVerifyApiClient()
         );
     }

--- a/src/ActiveLogin.Authentication.BankId.Core/IBankIdBuilderExtensions.cs
+++ b/src/ActiveLogin.Authentication.BankId.Core/IBankIdBuilderExtensions.cs
@@ -288,10 +288,8 @@ public static class IBankIdBuilderExtensions
         var options = new BankIdSimulatedEnvironmentOptions();
         configure(options);
 
-        var collectStates = new List<BankIdSimulatedAppApiClient.CollectState>(options.CollectStates);
-
         return UseSimulatedEnvironment(builder,
-            x => new BankIdSimulatedAppApiClient(collectStates),
+            x => new BankIdSimulatedAppApiClient(options.CollectStates),
             x => new BankIdSimulatedVerifyApiClient()
         );
     }

--- a/src/ActiveLogin.Authentication.BankId.Core/IBankIdBuilderExtensions.cs
+++ b/src/ActiveLogin.Authentication.BankId.Core/IBankIdBuilderExtensions.cs
@@ -292,8 +292,10 @@ public static class IBankIdBuilderExtensions
             throw new ArgumentException("At least one collect state must be configured.", nameof(configure));
         }
 
+        var collectStates = new List<BankIdSimulatedAppApiClient.CollectState>(options.CollectStates);
+
         return UseSimulatedEnvironment(builder,
-            x => new BankIdSimulatedAppApiClient(options.CollectStates),
+            x => new BankIdSimulatedAppApiClient(collectStates),
             x => new BankIdSimulatedVerifyApiClient()
         );
     }

--- a/test/ActiveLogin.Authentication.BankId.Api.Test/BankIdSimulatedAppApiClient_Tests.cs
+++ b/test/ActiveLogin.Authentication.BankId.Api.Test/BankIdSimulatedAppApiClient_Tests.cs
@@ -238,4 +238,28 @@ public class BankIdSimulatedAppApiClient_Tests
         Assert.Equal(CollectStatus.Pending, firstCollectResponse.GetCollectStatus());
         Assert.Equal(CollectStatus.Complete, secondCollectResponse.GetCollectStatus());
     }
+
+    [Fact]
+    public async Task CollectAsync_WithCustomCollectStates__ShouldNotBeAffectedByChangesToOriginalList()
+    {
+        // Arange
+        var states = new List<BankIdSimulatedAppApiClient.CollectState>
+        {
+            new(CollectStatus.Pending, CollectHintCode.NoClient),
+            new(CollectStatus.Complete, CollectHintCode.UserSign)
+        };
+        var bankIdClient = new BankIdSimulatedAppApiClient(states)
+        {
+            Delay = TimeSpan.Zero
+        };
+        states.Clear();
+
+        // Act
+        var authResponse = await bankIdClient.AuthAsync(new AuthRequest("1.1.1.1"));
+        var collectResponse = await bankIdClient.CollectAsync(new CollectRequest(authResponse.OrderRef));
+
+        // Assert
+        Assert.Equal(CollectStatus.Pending, collectResponse.GetCollectStatus());
+        Assert.Equal(CollectHintCode.NoClient, collectResponse.GetCollectHintCode());
+    }
 }

--- a/test/ActiveLogin.Authentication.BankId.Api.Test/BankIdSimulatedAppApiClient_Tests.cs
+++ b/test/ActiveLogin.Authentication.BankId.Api.Test/BankIdSimulatedAppApiClient_Tests.cs
@@ -262,4 +262,16 @@ public class BankIdSimulatedAppApiClient_Tests
         Assert.Equal(CollectStatus.Pending, collectResponse.GetCollectStatus());
         Assert.Equal(CollectHintCode.NoClient, collectResponse.GetCollectHintCode());
     }
+
+    [Fact]
+    public void Constructor_WithNullCollectStates__ShouldThrowArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => new BankIdSimulatedAppApiClient(null!));
+    }
+
+    [Fact]
+    public void Constructor_WithEmptyCollectStates__ShouldThrowArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => new BankIdSimulatedAppApiClient(new List<BankIdSimulatedAppApiClient.CollectState>()));
+    }
 }

--- a/test/ActiveLogin.Authentication.BankId.Api.Test/BankIdSimulatedAppApiClient_Tests.cs
+++ b/test/ActiveLogin.Authentication.BankId.Api.Test/BankIdSimulatedAppApiClient_Tests.cs
@@ -193,4 +193,49 @@ public class BankIdSimulatedAppApiClient_Tests
         // Assert
         await Assert.ThrowsAsync<BankIdApiException>(() => bankIdClient.CollectAsync(new CollectRequest(authResponse.OrderRef)));
     }
+
+    [Fact]
+    public async Task CollectAsync_WithCustomCollectStates__ShouldReturnConfiguredStates()
+    {
+        // Arange
+        var states = new List<BankIdSimulatedAppApiClient.CollectState>
+        {
+            new(CollectStatus.Pending, CollectHintCode.NoClient),
+            new(CollectStatus.Complete, CollectHintCode.UserSign)
+        };
+        var bankIdClient = new BankIdSimulatedAppApiClient(states)
+        {
+            Delay = TimeSpan.Zero
+        };
+
+        // Act
+        var authResponse = await bankIdClient.AuthAsync(new AuthRequest("1.1.1.1"));
+        var firstCollectResponse = await bankIdClient.CollectAsync(new CollectRequest(authResponse.OrderRef));
+        var secondCollectResponse = await bankIdClient.CollectAsync(new CollectRequest(authResponse.OrderRef));
+
+        // Assert
+        Assert.Equal(CollectStatus.Pending, firstCollectResponse.GetCollectStatus());
+        Assert.Equal(CollectHintCode.NoClient, firstCollectResponse.GetCollectHintCode());
+        Assert.Equal(CollectStatus.Complete, secondCollectResponse.GetCollectStatus());
+        Assert.Equal(CollectHintCode.UserSign, secondCollectResponse.GetCollectHintCode());
+    }
+
+    [Fact]
+    public async Task CollectAsync_WithFastCollectStates__ShouldCompleteAfterOnePendingState()
+    {
+        // Arange
+        var bankIdClient = new BankIdSimulatedAppApiClient(BankIdSimulatedAppApiClient.FastCollectStates)
+        {
+            Delay = TimeSpan.Zero
+        };
+
+        // Act
+        var authResponse = await bankIdClient.AuthAsync(new AuthRequest("1.1.1.1"));
+        var firstCollectResponse = await bankIdClient.CollectAsync(new CollectRequest(authResponse.OrderRef));
+        var secondCollectResponse = await bankIdClient.CollectAsync(new CollectRequest(authResponse.OrderRef));
+
+        // Assert
+        Assert.Equal(CollectStatus.Pending, firstCollectResponse.GetCollectStatus());
+        Assert.Equal(CollectStatus.Complete, secondCollectResponse.GetCollectStatus());
+    }
 }

--- a/test/ActiveLogin.Authentication.BankId.Core.Test/BankIdBuilder_Tests.cs
+++ b/test/ActiveLogin.Authentication.BankId.Core.Test/BankIdBuilder_Tests.cs
@@ -45,7 +45,6 @@ public class BankIdBuilderTests
         };
 
         builder.UseSimulatedEnvironment(options => options.CollectStates = states);
-        states.Clear();
 
         using var serviceProvider = services.BuildServiceProvider();
         var client = Assert.IsType<BankIdSimulatedAppApiClient>(serviceProvider.GetRequiredService<IBankIdAppApiClient>());

--- a/test/ActiveLogin.Authentication.BankId.Core.Test/BankIdBuilder_Tests.cs
+++ b/test/ActiveLogin.Authentication.BankId.Core.Test/BankIdBuilder_Tests.cs
@@ -45,6 +45,7 @@ public class BankIdBuilderTests
         };
 
         builder.UseSimulatedEnvironment(options => options.CollectStates = states);
+        states.Clear();
 
         using var serviceProvider = services.BuildServiceProvider();
         var client = Assert.IsType<BankIdSimulatedAppApiClient>(serviceProvider.GetRequiredService<IBankIdAppApiClient>());

--- a/test/ActiveLogin.Authentication.BankId.Core.Test/BankIdBuilder_Tests.cs
+++ b/test/ActiveLogin.Authentication.BankId.Core.Test/BankIdBuilder_Tests.cs
@@ -1,6 +1,9 @@
 using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 
 using ActiveLogin.Authentication.BankId.Api;
+using ActiveLogin.Authentication.BankId.Api.Models;
 
 using Microsoft.Extensions.DependencyInjection;
 
@@ -28,6 +31,31 @@ public class BankIdBuilderTests
         var exception = Assert.Throws<InvalidOperationException>(() => builder.AddSimulatedApiErrors());
         Assert.Equal("No IBankIdAppApiClient implementation found in the service collection.", exception.Message);
 
+    }
+
+    [Fact]
+    public async Task UseSimulatedEnvironment_WithOptions__RegistersConfiguredCollectStates()
+    {
+        var services = new ServiceCollection();
+        var builder = new BankIdBuilder(services);
+        var states = new List<BankIdSimulatedAppApiClient.CollectState>
+        {
+            new(CollectStatus.Pending, CollectHintCode.NoClient),
+            new(CollectStatus.Complete, CollectHintCode.UserSign)
+        };
+
+        builder.UseSimulatedEnvironment(options => options.CollectStates = states);
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var client = Assert.IsType<BankIdSimulatedAppApiClient>(serviceProvider.GetRequiredService<IBankIdAppApiClient>());
+        client.Delay = TimeSpan.Zero;
+        var authResponse = await client.AuthAsync(new AuthRequest("1.1.1.1"));
+        var firstCollectResponse = await client.CollectAsync(new CollectRequest(authResponse.OrderRef));
+        var secondCollectResponse = await client.CollectAsync(new CollectRequest(authResponse.OrderRef));
+
+        Assert.Equal(CollectStatus.Pending, firstCollectResponse.GetCollectStatus());
+        Assert.Equal(CollectHintCode.NoClient, firstCollectResponse.GetCollectHintCode());
+        Assert.Equal(CollectStatus.Complete, secondCollectResponse.GetCollectStatus());
     }
 
 }


### PR DESCRIPTION
This PR fixes #397.

High level overview of this PR:

- [x] Allow `UseSimulatedEnvironment` to configure the collect-state sequence used during simulated authentication.
- [x] Add reusable `Normal`, `Fast`, and `AllSuccessful` collect-state sequences while preserving the existing default behavior.
- [x] Make custom collect-state configuration safer by validating the input and avoiding unexpected changes when the caller mutates the original list.
- [x] Clarify that `AllSuccessfulCollectStates` covers successful UI states and intentionally excludes failed terminal states.
- [x] Keep response-delay configuration outside the scope of this issue.

These things have been implemented:

- [x] Code written
- [x] Test added
- [x] Documentation updated / written